### PR TITLE
remove: drop py39 support

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,12 +7,12 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.14"]
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,6 +28,7 @@ jobs:
         run: uv sync --dev
 
       - name: Run unittest tests in pure python mode
+        shell: bash
         run: |
           if uv run pytest tests --no-header --no-summary -v; then
             echo "Pytest succeeded."

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -5,9 +5,6 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -16,7 +13,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
 
       - name: Install dependencies
         run: uv sync --dev

--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -8,12 +8,6 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-
     steps:
       - uses: actions/checkout@v7
         with:
@@ -22,7 +16,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
 
       - name: Install dependencies
         run: uv sync --dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Dropped support for Python ≤3.9. `requires-python` is now `>=3.10`; trove classifiers and
+  `uv.lock` resolution markers for 3.9 have been removed accordingly.
+
+### Changed
+- Modernized type hints across the codebase, enabled by the Python 3.10 floor:
+  `Optional[X]`/`Union[X, Y]` → `X | None`/`X | Y` (`dfu.py`, `dfu_file.py`, `dfu_util.py`,
+  `dfuse.py`, `dfuse_mem.py`, `exceptions.py`, `lsusb.py`, `progress.py`, `__main__.py`,
+  `usb_dfu.py`, `quirks.py`, `usb-stubs/core.pyi`, `usb-stubs/util.pyi`); `typing.Generator`/
+  `Callable`/`Iterable`/`Iterator` (PEP 585, deprecated aliases of the `collections.abc` ABCs)
+  → `collections.abc` (`dfu_util.py`, `lsusb.py`, `dfuse_mem.py`, `usb-stubs/core.pyi`,
+  `usb-stubs/util.pyi`, `usb-stubs/backend/libusb1.pyi`).
+- Added `from __future__ import annotations` (PEP 563) to every module in `pydfuutil/`, and
+  dropped the now-unnecessary quotes on self-referencing forward-ref annotations
+  (`DfuIf.next` in `dfu.py`; `MemSegment.next`/`from_bytes`/`append`/`find` in `dfuse_mem.py`;
+  `FuncDescriptor.from_bytes` in `usb_dfu.py`, also dropping its `# noqa: F821`).
+- Bumped dev dependencies (`pytest`, `ty`, `pre-commit`) and regenerated `uv.lock`.
+- Reformatted the codebase and `usb-stubs/` with the current `ruff` (double-quote strings,
+  uppercase hex literals, updated line-wrapping).
+
+### Fixed
+- `dfuse_mem.py`/`dfu.py`: `MemSegment`/`DfuIf.next` self-referencing type hints were written as
+  `"ClassName" | None` — a string literal `|`'d with `None`, which is invalid at runtime and broke
+  both `ty` and every test importing `pydfuutil.dfu` under Python 3.14's dataclass annotation
+  evaluation. Fixed by quoting the whole union (`"ClassName | None"`).
 
 ## [0.11.0] - 2026-07-11
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # PyDfuUtil - Pure python fork of **[dfu-util](https://dfu-util.sourceforge.net/)** wrappers to **[libusb](https://github.com/libusb/libusb)**
 
+![GitHub License](https://img.shields.io/github/license/o-murphy/pydfuutil)
 [![PyPI Version](https://img.shields.io/pypi/v/pydfuutil?label=PyPI&logo=pypi)](https://pypi.org/project/pydfuutil/)
+![PyPI Python Version](https://img.shields.io/pypi/pyversions/pydfuutil)
 
 ## Table of contents
 * **[Introduction](#introduction)**

--- a/pydfuutil/__init__.py
+++ b/pydfuutil/__init__.py
@@ -18,6 +18,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
 
+from __future__ import annotations
+
 __author__ = "o-murphy"
 __credits__ = ("Dmytro Yaroshenko",)
 __copyright__ = ('2023 Yaroshenko Dmytro (https://github.com/o-murphy)',)

--- a/pydfuutil/__main__.py
+++ b/pydfuutil/__main__.py
@@ -20,13 +20,15 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
 
+from __future__ import annotations
+
 import argparse
 import importlib.metadata
 import logging
 import os
 import sys
 from enum import Enum
-from typing import Any, Optional, Literal, Union
+from typing import Any, Literal
 
 import usb.core
 import usb.util
@@ -94,7 +96,7 @@ class Mode(Enum):
     DOWNLOAD = 5
 
 
-def parse_serial(string: Optional[str]) -> None:
+def parse_serial(string: str | None) -> None:
     """parse serial"""
     if string in (None, ""):
         return
@@ -114,7 +116,7 @@ def parse_serial(string: Optional[str]) -> None:
         DfuUtil.match_serial_dfu = None
 
 
-def parse_match_value(string: Optional[str], default_value: int) -> int:
+def parse_match_value(string: str | None, default_value: int) -> int:
     """Parse a single vendor/product match token (hex, `*` = any, `-` = impossible)"""
     if string is None:
         return default_value
@@ -128,7 +130,7 @@ def parse_match_value(string: Optional[str], default_value: int) -> int:
         return default_value
 
 
-def parse_vendprod(string: Optional[str]) -> None:
+def parse_vendprod(string: str | None) -> None:
     """parse -d/--device <vid>:<pid>[,<vid_dfu>:<pid_dfu>]"""
     DfuUtil.match_vendor = -1
     DfuUtil.match_product = -1
@@ -148,11 +150,11 @@ def parse_vendprod(string: Optional[str]) -> None:
         if comma_index == -1:
             runtime_part, dfu_part = string, None
         else:
-            runtime_part, dfu_part = string[:comma_index], string[comma_index + 1:]
+            runtime_part, dfu_part = string[:comma_index], string[comma_index + 1 :]
 
         colon_index = runtime_part.find(":")
         vendor_str = runtime_part if colon_index == -1 else runtime_part[:colon_index]
-        product_str = None if colon_index == -1 else runtime_part[colon_index + 1:]
+        product_str = None if colon_index == -1 else runtime_part[colon_index + 1 :]
 
         DfuUtil.match_vendor = parse_match_value(vendor_str, DfuUtil.match_vendor)
         DfuUtil.match_product = parse_match_value(product_str, DfuUtil.match_product)
@@ -167,14 +169,18 @@ def parse_vendprod(string: Optional[str]) -> None:
     if dfu_part is not None:
         colon_index = dfu_part.find(":")
         vendor_dfu_str = dfu_part if colon_index == -1 else dfu_part[:colon_index]
-        product_dfu_str = None if colon_index == -1 else dfu_part[colon_index + 1:]
+        product_dfu_str = None if colon_index == -1 else dfu_part[colon_index + 1 :]
 
-        DfuUtil.match_vendor_dfu = parse_match_value(vendor_dfu_str, DfuUtil.match_vendor_dfu)
-        DfuUtil.match_product_dfu = parse_match_value(product_dfu_str, DfuUtil.match_product_dfu)
+        DfuUtil.match_vendor_dfu = parse_match_value(
+            vendor_dfu_str, DfuUtil.match_vendor_dfu
+        )
+        DfuUtil.match_product_dfu = parse_match_value(
+            product_dfu_str, DfuUtil.match_product_dfu
+        )
 
 
 def int_(
-    value: Union[int, bytes, bytearray], order: Literal["little", "big"] = "little"
+    value: int | bytes | bytearray, order: Literal["little", "big"] = "little"
 ) -> int:
     """coerce value to int"""
     if isinstance(value, int):
@@ -548,7 +554,9 @@ def main():
             # open for "exclusive" writing
             assert file.name is not None
             try:
-                fd = os.open(file.name, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_TRUNC)
+                fd = os.open(
+                    file.name, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_TRUNC
+                )
                 with os.fdopen(fd, "wb") as file.file_p:
                     if dfuse_device or dfuse_options:
                         ret = dfuse.do_upload(

--- a/pydfuutil/dfu.py
+++ b/pydfuutil/dfu.py
@@ -17,10 +17,10 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
 
-import sys
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import IntEnum, IntFlag
-from typing import Optional, Union
 
 import usb.core
 import usb.util
@@ -33,11 +33,12 @@ from pydfuutil.portable import milli_sleep
 from pydfuutil.quirks import QUIRK, DEFAULT_POLLTIMEOUT
 from pydfuutil.usb_dfu import FuncDescriptor
 
-_logger = logger.getChild('dfu')
+_logger = logger.getChild("dfu")
 
 
 class State(IntEnum):
     """Dfu states"""
+
     APP_IDLE = 0x00
     APP_DETACH = 0x01
     DFU_IDLE = 0x02
@@ -48,7 +49,7 @@ class State(IntEnum):
     DFU_MANIFEST = 0x07
     DFU_MANIFEST_WAIT_RESET = 0x08
     DFU_UPLOAD_IDLE = 0x09
-    DFU_ERROR = 0x0a
+    DFU_ERROR = 0x0A
 
     UNKNOWN_ERROR = -1
 
@@ -61,6 +62,7 @@ class State(IntEnum):
 
 class Status(IntEnum):
     """Dfu statuses"""
+
     OK = 0x00
     ERROR_TARGET = 0x01
     ERROR_FILE = 0x02
@@ -71,12 +73,12 @@ class Status(IntEnum):
     ERROR_VERIFY = 0x07
     ERROR_ADDRESS = 0x08
     ERROR_NOTDONE = 0x09
-    ERROR_FIRMWARE = 0x0a
-    ERROR_VENDOR = 0x0b
-    ERROR_USBR = 0x0c
-    ERROR_POR = 0x0d
-    ERROR_UNKNOWN = 0x0e
-    ERROR_STALLEDPKT = 0x0f
+    ERROR_FIRMWARE = 0x0A
+    ERROR_VENDOR = 0x0B
+    ERROR_USBR = 0x0C
+    ERROR_POR = 0x0D
+    ERROR_UNKNOWN = 0x0E
+    ERROR_STALLEDPKT = 0x0F
 
     def to_string(self):
         """
@@ -87,6 +89,7 @@ class Status(IntEnum):
 
 class Request(IntEnum):
     """Dfu commands"""
+
     DETACH = 0
     DNLOAD = 1
     UPLOAD = 2
@@ -99,6 +102,7 @@ class Request(IntEnum):
 # /* DFU interface */
 class IFF(IntFlag):
     """Dfu modes"""
+
     DFU = 0x0001  # /* DFU Mode, (not Runtime) */
     ALT = 0x0002  # /* Multiple alternate settings */
 
@@ -113,6 +117,7 @@ class StatusRetVal:
     This is based off of DFU_GETSTATUS
     the data structure to be populated with the results
     """
+
     # pylint: disable=invalid-name
     bStatus: Status = Status.ERROR_UNKNOWN
     bwPollTimeout: int = 0
@@ -123,58 +128,57 @@ class StatusRetVal:
     def from_bytes(cls, data: bytes):
         """Creates StatusRetVal instance from bytes sequence"""
         if len(data) >= 6:
-            bStatus = (Status(data[0])
-                       if data[0] in Status.__members__.values()
-                       else Status.ERROR_UNKNOWN)
-            bwPollTimeout = int.from_bytes(data[1:4], 'little')
-            bState = (State(data[4])
-                      if data[4] in State.__members__.values()
-                      else State.DFU_ERROR)
-            iString = data[5]
-            return cls(
-                bStatus,
-                bwPollTimeout,
-                bState,
-                iString
+            bStatus = (
+                Status(data[0])
+                if data[0] in Status.__members__.values()
+                else Status.ERROR_UNKNOWN
             )
+            bwPollTimeout = int.from_bytes(data[1:4], "little")
+            bState = (
+                State(data[4])
+                if data[4] in State.__members__.values()
+                else State.DFU_ERROR
+            )
+            iString = data[5]
+            return cls(bStatus, bwPollTimeout, bState, iString)
         return cls()
 
     def __bytes__(self) -> bytes:
         return (
-                bytes([self.bStatus.value])
-                + self.bwPollTimeout.to_bytes(3, 'little')
-                + bytes([self.bState.value, self.iString])
+            bytes([self.bStatus.value])
+            + self.bwPollTimeout.to_bytes(3, "little")
+            + bytes([self.bState.value, self.iString])
         )
 
     def __int__(self):
-        return int.from_bytes(self, 'little')
+        return int.from_bytes(self, "little")
 
 
 @dataclass
 class DfuIf:  # pylint: disable=too-many-instance-attributes
     """DFU Interface dataclass"""
+
     # pylint: disable=invalid-name
-    vendor: Optional[int] = None
-    product: Optional[int] = None
-    bcdDevice: Optional[int] = None
-    configuration: Optional[int] = None
-    interface: Optional[int] = None
-    altsetting: Optional[int] = None
-    alt_name: Optional[str] = None
-    bus: Optional[int] = None
-    devnum: Optional[int] = None
-    path: Optional[Union[str, int]] = None  # FIXME: deprecated
-    flags: Union[IFF, int] = 0
-    count: Optional[int] = None  # FIXME: deprecated
-    dev: Optional[usb.core.Device] = None
-    quirks: Optional[int] = None
+    vendor: int | None = None
+    product: int | None = None
+    bcdDevice: int | None = None
+    configuration: int | None = None
+    interface: int | None = None
+    altsetting: int | None = None
+    alt_name: str | None = None
+    bus: int | None = None
+    devnum: int | None = None
+    path: str | int | None = None  # FIXME: deprecated
+    flags: IFF | int = 0
+    count: int | None = None  # FIXME: deprecated
+    dev: usb.core.Device | None = None
+    quirks: int | None = None
     bwPollTimeout: int = 0
     bMaxPacketSize0: int = 0
     serial_name: str = ""
-    func_dfu: Optional[FuncDescriptor] = None
-    next: Optional['DfuIf'] = None
-    mem_layout: Optional[MemSegment] = None
-
+    func_dfu: FuncDescriptor | None = None
+    next: DfuIf | None = None
+    mem_layout: MemSegment | None = None
 
     @property
     def device_ids(self) -> dict:
@@ -195,13 +199,15 @@ class DfuIf:  # pylint: disable=too-many-instance-attributes
         assert self.interface is not None
         return _detach(self.dev, self.interface, timeout)
 
-    def download(self, transaction: int, data_or_length: Optional[Union[bytes, bytearray, int]]) -> int:
+    def download(
+        self, transaction: int, data_or_length: bytes | bytearray | int | None
+    ) -> int:
         """Binds self to dfu.download()"""
         assert self.dev is not None
         assert self.interface is not None
         return _download(self.dev, self.interface, transaction, data_or_length)
 
-    def upload(self, transaction: int, data_or_length: Union[bytes, int]) -> bytes:
+    def upload(self, transaction: int, data_or_length: bytes | int) -> bytes:
         """Binds self to dfu.upload()"""
         assert self.dev is not None
         assert self.interface is not None
@@ -279,11 +285,11 @@ def _detach(device: usb.core.Device, interface: int, timeout: int) -> int:
     :return: bytes written or < 0 on error
     """
 
-    _logger.debug('DETACH...')
+    _logger.debug("DETACH...")
     result = device.ctrl_transfer(
         bmRequestType=usb.util.ENDPOINT_OUT
-                      | usb.util.CTRL_TYPE_CLASS
-                      | usb.util.CTRL_RECIPIENT_INTERFACE,
+        | usb.util.CTRL_TYPE_CLASS
+        | usb.util.CTRL_RECIPIENT_INTERFACE,
         bRequest=Request.DETACH,
         wValue=timeout,
         wIndex=interface,
@@ -291,14 +297,16 @@ def _detach(device: usb.core.Device, interface: int, timeout: int) -> int:
         timeout=TIMEOUT,
     )
     assert isinstance(result, int)
-    _logger.debug(f'DETACH {result >= 0}')
+    _logger.debug(f"DETACH {result >= 0}")
     return result
 
 
-def _download(device: usb.core.Device,
-              interface: int,
-              transaction: int,
-              data_or_length: Optional[Union[bytes, bytearray, int]]) -> int:
+def _download(
+    device: usb.core.Device,
+    interface: int,
+    transaction: int,
+    data_or_length: bytes | bytearray | int | None,
+) -> int:
     """
     DNLOAD Request (DFU Spec 1.0, Section 6.1.1)
 
@@ -310,12 +318,12 @@ def _download(device: usb.core.Device,
     :return: downloaded data or error code in bytes
     """
 
-    _logger.debug('DFU_DOWNLOAD...')
+    _logger.debug("DFU_DOWNLOAD...")
 
     result = device.ctrl_transfer(
         bmRequestType=usb.util.ENDPOINT_OUT
-                      | usb.util.CTRL_TYPE_CLASS
-                      | usb.util.CTRL_RECIPIENT_INTERFACE,
+        | usb.util.CTRL_TYPE_CLASS
+        | usb.util.CTRL_RECIPIENT_INTERFACE,
         bRequest=Request.DNLOAD,
         wValue=transaction,
         wIndex=interface,
@@ -324,14 +332,16 @@ def _download(device: usb.core.Device,
     )
 
     assert isinstance(result, int)
-    _logger.debug(f'DFU_DOWNLOAD {result >= 0}')
+    _logger.debug(f"DFU_DOWNLOAD {result >= 0}")
     return result
 
 
-def _upload(device: usb.core.Device,
-            interface: int,
-            transaction: int,
-            data_or_length: Union[bytes, int]) -> bytes:
+def _upload(
+    device: usb.core.Device,
+    interface: int,
+    transaction: int,
+    data_or_length: bytes | int,
+) -> bytes:
     """
     UPLOAD Request (DFU Spec 1.0, Section 6.2)
 
@@ -343,11 +353,11 @@ def _upload(device: usb.core.Device,
     :return: uploaded bytes or < 0 on error
     """
 
-    _logger.debug('UPLOAD...')
+    _logger.debug("UPLOAD...")
     result = device.ctrl_transfer(
         bmRequestType=usb.util.ENDPOINT_IN
-                      | usb.util.CTRL_TYPE_CLASS
-                      | usb.util.CTRL_RECIPIENT_INTERFACE,
+        | usb.util.CTRL_TYPE_CLASS
+        | usb.util.CTRL_RECIPIENT_INTERFACE,
         bRequest=Request.UPLOAD,
         wValue=transaction,
         wIndex=interface,
@@ -355,7 +365,7 @@ def _upload(device: usb.core.Device,
         timeout=TIMEOUT,
     )
     assert not isinstance(result, int)
-    _logger.debug(f'UPLOAD {len(result) >= 0}')
+    _logger.debug(f"UPLOAD {len(result) >= 0}")
 
     return result.tobytes()
 
@@ -370,13 +380,13 @@ def _get_status(device: usb.core.Device, interface: int) -> StatusRetVal:
     :return: StatusRetVal
     """
 
-    _logger.debug('DFU_GET_STATUS...')
+    _logger.debug("DFU_GET_STATUS...")
 
     length = 6
     result = device.ctrl_transfer(
         bmRequestType=usb.util.ENDPOINT_IN
-                      | usb.util.CTRL_TYPE_CLASS
-                      | usb.util.CTRL_RECIPIENT_INTERFACE,
+        | usb.util.CTRL_TYPE_CLASS
+        | usb.util.CTRL_RECIPIENT_INTERFACE,
         bRequest=Request.GETSTATUS,
         wValue=0,
         wIndex=interface,
@@ -387,8 +397,8 @@ def _get_status(device: usb.core.Device, interface: int) -> StatusRetVal:
 
     if len(result) == length:
         status = StatusRetVal.from_bytes(result.tobytes())
-        _logger.debug(f'GET_STATUS {len(result) == 6}')
-        _logger.debug(f'CURRENT STATE {status.bState.to_string()}')
+        _logger.debug(f"GET_STATUS {len(result) == 6}")
+        _logger.debug(f"CURRENT STATE {status.bState.to_string()}")
         return status
     return StatusRetVal.from_bytes(result.tobytes())
 
@@ -403,12 +413,12 @@ def _clear_status(device: usb.core.Device, interface: int) -> int:
     :return: return 0 or < 0 on an error
     """
 
-    _logger.debug('CLEAR_STATUS...')
+    _logger.debug("CLEAR_STATUS...")
 
     result = device.ctrl_transfer(
         bmRequestType=usb.util.ENDPOINT_OUT
-                      | usb.util.CTRL_TYPE_CLASS
-                      | usb.util.CTRL_RECIPIENT_INTERFACE,
+        | usb.util.CTRL_TYPE_CLASS
+        | usb.util.CTRL_RECIPIENT_INTERFACE,
         bRequest=Request.CLRSTATUS,
         wValue=0,
         wIndex=interface,
@@ -416,7 +426,7 @@ def _clear_status(device: usb.core.Device, interface: int) -> int:
         timeout=TIMEOUT,
     )
     assert isinstance(result, int)
-    _logger.debug(f'CLEAR_STATUS {result >= 0}')
+    _logger.debug(f"CLEAR_STATUS {result >= 0}")
 
     return result
 
@@ -434,8 +444,8 @@ def _get_state(device: usb.core.Device, interface: int) -> State:
     length = 1
     result = device.ctrl_transfer(
         bmRequestType=usb.util.ENDPOINT_IN
-                      | usb.util.CTRL_TYPE_CLASS
-                      | usb.util.CTRL_RECIPIENT_INTERFACE,
+        | usb.util.CTRL_TYPE_CLASS
+        | usb.util.CTRL_RECIPIENT_INTERFACE,
         bRequest=Request.GETSTATE,
         wValue=0,
         wIndex=interface,
@@ -461,12 +471,12 @@ def _abort(device: usb.core.Device, interface: int) -> int:
     :return: returns 0 or < 0 on an error
     """
 
-    _logger.debug('ABORT...')
+    _logger.debug("ABORT...")
 
     result = device.ctrl_transfer(
         bmRequestType=usb.util.ENDPOINT_OUT
-                      | usb.util.CTRL_TYPE_CLASS
-                      | usb.util.CTRL_RECIPIENT_INTERFACE,
+        | usb.util.CTRL_TYPE_CLASS
+        | usb.util.CTRL_RECIPIENT_INTERFACE,
         bRequest=Request.ABORT,
         wValue=0,
         wIndex=interface,
@@ -475,12 +485,12 @@ def _abort(device: usb.core.Device, interface: int) -> int:
     )
     assert isinstance(result, int)
 
-    _logger.debug(f'ABORT {result >= 0}')
+    _logger.debug(f"ABORT {result >= 0}")
 
     return result
 
 
-def _state_to_string(state: int) -> Optional[str]:
+def _state_to_string(state: int) -> str | None:
     """
     :param state:
     :return: State name by State Enum
@@ -491,7 +501,7 @@ def _state_to_string(state: int) -> Optional[str]:
         return None
 
 
-def _status_to_string(status: int) -> Optional[str]:
+def _status_to_string(status: int) -> str | None:
     """
     :param status:
     :return: State name by Status Enum
@@ -503,17 +513,17 @@ def _status_to_string(status: int) -> Optional[str]:
 
 
 _STATES_NAMES = {
-    State.APP_IDLE: 'appIDLE',
-    State.APP_DETACH: 'appDETACH',
-    State.DFU_IDLE: 'dfuIDLE',
-    State.DFU_DOWNLOAD_SYNC: 'dfuDNLOAD-SYNC',
-    State.DFU_DOWNLOAD_BUSY: 'dfuDNBUSY',
-    State.DFU_DOWNLOAD_IDLE: 'dfuDNLOAD-IDLE',
-    State.DFU_MANIFEST_SYNC: 'dfuMANIFEST-SYNC',
-    State.DFU_MANIFEST: 'dfuMANIFEST',
-    State.DFU_MANIFEST_WAIT_RESET: 'dfuMANIFEST-WAIT-RESET',
-    State.DFU_UPLOAD_IDLE: 'dfuUPLOAD-IDLE',
-    State.DFU_ERROR: 'dfuERROR',
+    State.APP_IDLE: "appIDLE",
+    State.APP_DETACH: "appDETACH",
+    State.DFU_IDLE: "dfuIDLE",
+    State.DFU_DOWNLOAD_SYNC: "dfuDNLOAD-SYNC",
+    State.DFU_DOWNLOAD_BUSY: "dfuDNBUSY",
+    State.DFU_DOWNLOAD_IDLE: "dfuDNLOAD-IDLE",
+    State.DFU_MANIFEST_SYNC: "dfuMANIFEST-SYNC",
+    State.DFU_MANIFEST: "dfuMANIFEST",
+    State.DFU_MANIFEST_WAIT_RESET: "dfuMANIFEST-WAIT-RESET",
+    State.DFU_UPLOAD_IDLE: "dfuUPLOAD-IDLE",
+    State.DFU_ERROR: "dfuERROR",
 }
 
 _DFU_STATUS_NAMES = {
@@ -527,14 +537,14 @@ _DFU_STATUS_NAMES = {
     Status.ERROR_VERIFY: "Programmed memory failed verification",
     Status.ERROR_ADDRESS: "Cannot program memory due to received address that is out of range",
     Status.ERROR_NOTDONE: "Received DNLOAD with wLength = 0, "
-                          "but device does not think that it has all data yet",
+    "but device does not think that it has all data yet",
     Status.ERROR_FIRMWARE: "Device's firmware is corrupt. "
-                           "It cannot return to run-time (non-DFU) operations",
+    "It cannot return to run-time (non-DFU) operations",
     Status.ERROR_VENDOR: "iString indicates a vendor specific error",
     Status.ERROR_USBR: "Device detected unexpected USB reset signalling",
     Status.ERROR_POR: "Device detected unexpected power on reset",
     Status.ERROR_UNKNOWN: "Something went wrong, but the device does not know what it was",
-    Status.ERROR_STALLEDPKT: "Device stalled an unexpected request"
+    Status.ERROR_STALLEDPKT: "Device stalled an unexpected request",
 }
 
 
@@ -563,12 +573,4 @@ TRANSACTION: int = 0
 
 DEBUG_LEVEL: int = 0
 
-__all__ = (
-    "Request",
-    "Status",
-    "State",
-    "StatusRetVal",
-    "DfuIf",
-    'IFF',
-    'init'
-)
+__all__ = ("Request", "Status", "State", "StatusRetVal", "DfuIf", "IFF", "init")

--- a/pydfuutil/dfu_file.py
+++ b/pydfuutil/dfu_file.py
@@ -17,6 +17,9 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
+
+from __future__ import annotations
+
 import errno
 import io
 import struct
@@ -24,12 +27,17 @@ import sys
 import warnings
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import Optional, Union
 
-from pydfuutil.exceptions import NoInputError, _IOError, DataError, except_and_safe_exit, UsageError
+from pydfuutil.exceptions import (
+    NoInputError,
+    _IOError,
+    DataError,
+    except_and_safe_exit,
+    UsageError,
+)
 from pydfuutil.logger import logger
 
-_logger = logger.getChild('dfu_file')
+_logger = logger.getChild("dfu_file")
 
 DFU_SUFFIX_LENGTH = 16
 LMDFU_PREFIX_LENGTH = 8
@@ -37,55 +45,269 @@ LPCDFU_PREFIX_LENGTH = 16
 STDIN_CHUNK_SIZE = 65536
 
 crc32_table = [
-    0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
-    0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
-    0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91, 0x1db71064, 0x6ab020f2,
-    0xf3b97148, 0x84be41de, 0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7,
-    0x136c9856, 0x646ba8c0, 0xfd62f97a, 0x8a65c9ec, 0x14015c4f, 0x63066cd9,
-    0xfa0f3d63, 0x8d080df5, 0x3b6e20c8, 0x4c69105e, 0xd56041e4, 0xa2677172,
-    0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b, 0x35b5a8fa, 0x42b2986c,
-    0xdbbbc9d6, 0xacbcf940, 0x32d86ce3, 0x45df5c75, 0xdcd60dcf, 0xabd13d59,
-    0x26d930ac, 0x51de003a, 0xc8d75180, 0xbfd06116, 0x21b4f4b5, 0x56b3c423,
-    0xcfba9599, 0xb8bda50f, 0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924,
-    0x2f6f7c87, 0x58684c11, 0xc1611dab, 0xb6662d3d, 0x76dc4190, 0x01db7106,
-    0x98d220bc, 0xefd5102a, 0x71b18589, 0x06b6b51f, 0x9fbfe4a5, 0xe8b8d433,
-    0x7807c9a2, 0x0f00f934, 0x9609a88e, 0xe10e9818, 0x7f6a0dbb, 0x086d3d2d,
-    0x91646c97, 0xe6635c01, 0x6b6b51f4, 0x1c6c6162, 0x856530d8, 0xf262004e,
-    0x6c0695ed, 0x1b01a57b, 0x8208f4c1, 0xf50fc457, 0x65b0d9c6, 0x12b7e950,
-    0x8bbeb8ea, 0xfcb9887c, 0x62dd1ddf, 0x15da2d49, 0x8cd37cf3, 0xfbd44c65,
-    0x4db26158, 0x3ab551ce, 0xa3bc0074, 0xd4bb30e2, 0x4adfa541, 0x3dd895d7,
-    0xa4d1c46d, 0xd3d6f4fb, 0x4369e96a, 0x346ed9fc, 0xad678846, 0xda60b8d0,
-    0x44042d73, 0x33031de5, 0xaa0a4c5f, 0xdd0d7cc9, 0x5005713c, 0x270241aa,
-    0xbe0b1010, 0xc90c2086, 0x5768b525, 0x206f85b3, 0xb966d409, 0xce61e49f,
-    0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4, 0x59b33d17, 0x2eb40d81,
-    0xb7bd5c3b, 0xc0ba6cad, 0xedb88320, 0x9abfb3b6, 0x03b6e20c, 0x74b1d29a,
-    0xead54739, 0x9dd277af, 0x04db2615, 0x73dc1683, 0xe3630b12, 0x94643b84,
-    0x0d6d6a3e, 0x7a6a5aa8, 0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1,
-    0xf00f9344, 0x8708a3d2, 0x1e01f268, 0x6906c2fe, 0xf762575d, 0x806567cb,
-    0x196c3671, 0x6e6b06e7, 0xfed41b76, 0x89d32be0, 0x10da7a5a, 0x67dd4acc,
-    0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5, 0xd6d6a3e8, 0xa1d1937e,
-    0x38d8c2c4, 0x4fdff252, 0xd1bb67f1, 0xa6bc5767, 0x3fb506dd, 0x48b2364b,
-    0xd80d2bda, 0xaf0a1b4c, 0x36034af6, 0x41047a60, 0xdf60efc3, 0xa867df55,
-    0x316e8eef, 0x4669be79, 0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236,
-    0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f, 0xc5ba3bbe, 0xb2bd0b28,
-    0x2bb45a92, 0x5cb36a04, 0xc2d7ffa7, 0xb5d0cf31, 0x2cd99e8b, 0x5bdeae1d,
-    0x9b64c2b0, 0xec63f226, 0x756aa39c, 0x026d930a, 0x9c0906a9, 0xeb0e363f,
-    0x72076785, 0x05005713, 0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38,
-    0x92d28e9b, 0xe5d5be0d, 0x7cdcefb7, 0x0bdbdf21, 0x86d3d2d4, 0xf1d4e242,
-    0x68ddb3f8, 0x1fda836e, 0x81be16cd, 0xf6b9265b, 0x6fb077e1, 0x18b74777,
-    0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c, 0x8f659eff, 0xf862ae69,
-    0x616bffd3, 0x166ccf45, 0xa00ae278, 0xd70dd2ee, 0x4e048354, 0x3903b3c2,
-    0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db, 0xaed16a4a, 0xd9d65adc,
-    0x40df0b66, 0x37d83bf0, 0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
-    0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6, 0xbad03605, 0xcdd70693,
-    0x54de5729, 0x23d967bf, 0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94,
-    0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d
+    0x00000000,
+    0x77073096,
+    0xEE0E612C,
+    0x990951BA,
+    0x076DC419,
+    0x706AF48F,
+    0xE963A535,
+    0x9E6495A3,
+    0x0EDB8832,
+    0x79DCB8A4,
+    0xE0D5E91E,
+    0x97D2D988,
+    0x09B64C2B,
+    0x7EB17CBD,
+    0xE7B82D07,
+    0x90BF1D91,
+    0x1DB71064,
+    0x6AB020F2,
+    0xF3B97148,
+    0x84BE41DE,
+    0x1ADAD47D,
+    0x6DDDE4EB,
+    0xF4D4B551,
+    0x83D385C7,
+    0x136C9856,
+    0x646BA8C0,
+    0xFD62F97A,
+    0x8A65C9EC,
+    0x14015C4F,
+    0x63066CD9,
+    0xFA0F3D63,
+    0x8D080DF5,
+    0x3B6E20C8,
+    0x4C69105E,
+    0xD56041E4,
+    0xA2677172,
+    0x3C03E4D1,
+    0x4B04D447,
+    0xD20D85FD,
+    0xA50AB56B,
+    0x35B5A8FA,
+    0x42B2986C,
+    0xDBBBC9D6,
+    0xACBCF940,
+    0x32D86CE3,
+    0x45DF5C75,
+    0xDCD60DCF,
+    0xABD13D59,
+    0x26D930AC,
+    0x51DE003A,
+    0xC8D75180,
+    0xBFD06116,
+    0x21B4F4B5,
+    0x56B3C423,
+    0xCFBA9599,
+    0xB8BDA50F,
+    0x2802B89E,
+    0x5F058808,
+    0xC60CD9B2,
+    0xB10BE924,
+    0x2F6F7C87,
+    0x58684C11,
+    0xC1611DAB,
+    0xB6662D3D,
+    0x76DC4190,
+    0x01DB7106,
+    0x98D220BC,
+    0xEFD5102A,
+    0x71B18589,
+    0x06B6B51F,
+    0x9FBFE4A5,
+    0xE8B8D433,
+    0x7807C9A2,
+    0x0F00F934,
+    0x9609A88E,
+    0xE10E9818,
+    0x7F6A0DBB,
+    0x086D3D2D,
+    0x91646C97,
+    0xE6635C01,
+    0x6B6B51F4,
+    0x1C6C6162,
+    0x856530D8,
+    0xF262004E,
+    0x6C0695ED,
+    0x1B01A57B,
+    0x8208F4C1,
+    0xF50FC457,
+    0x65B0D9C6,
+    0x12B7E950,
+    0x8BBEB8EA,
+    0xFCB9887C,
+    0x62DD1DDF,
+    0x15DA2D49,
+    0x8CD37CF3,
+    0xFBD44C65,
+    0x4DB26158,
+    0x3AB551CE,
+    0xA3BC0074,
+    0xD4BB30E2,
+    0x4ADFA541,
+    0x3DD895D7,
+    0xA4D1C46D,
+    0xD3D6F4FB,
+    0x4369E96A,
+    0x346ED9FC,
+    0xAD678846,
+    0xDA60B8D0,
+    0x44042D73,
+    0x33031DE5,
+    0xAA0A4C5F,
+    0xDD0D7CC9,
+    0x5005713C,
+    0x270241AA,
+    0xBE0B1010,
+    0xC90C2086,
+    0x5768B525,
+    0x206F85B3,
+    0xB966D409,
+    0xCE61E49F,
+    0x5EDEF90E,
+    0x29D9C998,
+    0xB0D09822,
+    0xC7D7A8B4,
+    0x59B33D17,
+    0x2EB40D81,
+    0xB7BD5C3B,
+    0xC0BA6CAD,
+    0xEDB88320,
+    0x9ABFB3B6,
+    0x03B6E20C,
+    0x74B1D29A,
+    0xEAD54739,
+    0x9DD277AF,
+    0x04DB2615,
+    0x73DC1683,
+    0xE3630B12,
+    0x94643B84,
+    0x0D6D6A3E,
+    0x7A6A5AA8,
+    0xE40ECF0B,
+    0x9309FF9D,
+    0x0A00AE27,
+    0x7D079EB1,
+    0xF00F9344,
+    0x8708A3D2,
+    0x1E01F268,
+    0x6906C2FE,
+    0xF762575D,
+    0x806567CB,
+    0x196C3671,
+    0x6E6B06E7,
+    0xFED41B76,
+    0x89D32BE0,
+    0x10DA7A5A,
+    0x67DD4ACC,
+    0xF9B9DF6F,
+    0x8EBEEFF9,
+    0x17B7BE43,
+    0x60B08ED5,
+    0xD6D6A3E8,
+    0xA1D1937E,
+    0x38D8C2C4,
+    0x4FDFF252,
+    0xD1BB67F1,
+    0xA6BC5767,
+    0x3FB506DD,
+    0x48B2364B,
+    0xD80D2BDA,
+    0xAF0A1B4C,
+    0x36034AF6,
+    0x41047A60,
+    0xDF60EFC3,
+    0xA867DF55,
+    0x316E8EEF,
+    0x4669BE79,
+    0xCB61B38C,
+    0xBC66831A,
+    0x256FD2A0,
+    0x5268E236,
+    0xCC0C7795,
+    0xBB0B4703,
+    0x220216B9,
+    0x5505262F,
+    0xC5BA3BBE,
+    0xB2BD0B28,
+    0x2BB45A92,
+    0x5CB36A04,
+    0xC2D7FFA7,
+    0xB5D0CF31,
+    0x2CD99E8B,
+    0x5BDEAE1D,
+    0x9B64C2B0,
+    0xEC63F226,
+    0x756AA39C,
+    0x026D930A,
+    0x9C0906A9,
+    0xEB0E363F,
+    0x72076785,
+    0x05005713,
+    0x95BF4A82,
+    0xE2B87A14,
+    0x7BB12BAE,
+    0x0CB61B38,
+    0x92D28E9B,
+    0xE5D5BE0D,
+    0x7CDCEFB7,
+    0x0BDBDF21,
+    0x86D3D2D4,
+    0xF1D4E242,
+    0x68DDB3F8,
+    0x1FDA836E,
+    0x81BE16CD,
+    0xF6B9265B,
+    0x6FB077E1,
+    0x18B74777,
+    0x88085AE6,
+    0xFF0F6A70,
+    0x66063BCA,
+    0x11010B5C,
+    0x8F659EFF,
+    0xF862AE69,
+    0x616BFFD3,
+    0x166CCF45,
+    0xA00AE278,
+    0xD70DD2EE,
+    0x4E048354,
+    0x3903B3C2,
+    0xA7672661,
+    0xD06016F7,
+    0x4969474D,
+    0x3E6E77DB,
+    0xAED16A4A,
+    0xD9D65ADC,
+    0x40DF0B66,
+    0x37D83BF0,
+    0xA9BCAE53,
+    0xDEBB9EC5,
+    0x47B2CF7F,
+    0x30B5FFE9,
+    0xBDBDF21C,
+    0xCABAC28A,
+    0x53B39330,
+    0x24B4A3A6,
+    0xBAD03605,
+    0xCDD70693,
+    0x54DE5729,
+    0x23D967BF,
+    0xB3667A2E,
+    0xC4614AB8,
+    0x5D681B02,
+    0x2A6F2B94,
+    0xB40BBE37,
+    0xC30C8EA1,
+    0x5A05DF1B,
+    0x2D02EF8D,
 ]
 
 
 @dataclass
 class DFUFileSize:
     """Dfu file size struct"""
+
     total: int = 0
     prefix: int = 0
     suffix: int = 0
@@ -93,6 +315,7 @@ class DFUFileSize:
 
 class SuffixReq(IntEnum):
     """Suffix requirement"""
+
     NO_SUFFIX = 0
     NEEDS_SUFFIX = 1
     MAYBE_SUFFIX = 2
@@ -100,6 +323,7 @@ class SuffixReq(IntEnum):
 
 class PrefixReq(IntEnum):
     """Prefix requirement"""
+
     NO_PREFIX = 0
     NEEDS_PREFIX = 1
     MAYBE_PREFIX = 2
@@ -107,6 +331,7 @@ class PrefixReq(IntEnum):
 
 class PrefixType(IntEnum):
     """Dfu prefix type"""
+
     ZERO_PREFIX = 0
     LMDFU_PREFIX = 1
     LPCDFU_UNENCRYPTED_PREFIX = 2
@@ -115,17 +340,18 @@ class PrefixType(IntEnum):
 @dataclass
 class DfuFile:  # pylint: disable=too-many-instance-attributes, invalid-name
     """Class to store DFU file data"""
-    name: Optional[str]
-    firmware: Union[bytearray, bytes] = field(default_factory=bytearray)
-    file_p: Optional[io.BufferedIOBase] = None
+
+    name: str | None
+    firmware: bytearray | bytes = field(default_factory=bytearray)
+    file_p: io.BufferedIOBase | None = None
     size: DFUFileSize = field(default_factory=DFUFileSize)
     lmdfu_address: int = 0
     prefix_type: PrefixType = PrefixType.ZERO_PREFIX
     dwCRC: int = 0
     bcdDFU: int = 0
-    idVendor: int = 0xffff  # wildcard value
-    idProduct: int = 0xffff  # wildcard value
-    bcdDevice: int = 0xffff  # wildcard value
+    idVendor: int = 0xFFFF  # wildcard value
+    idProduct: int = 0xFFFF  # wildcard value
+    bcdDevice: int = 0xFFFF  # wildcard value
 
     def dump(self, write_suffix: bool, write_prefix: bool) -> None:
         """writes suffix and/or prefix to dfu file"""
@@ -135,7 +361,7 @@ class DfuFile:  # pylint: disable=too-many-instance-attributes, invalid-name
         """loads suffix and/or prefix from dfu file"""
         return _load_file(self, check_suffix, check_prefix)
 
-    def write_crc(self, crc: int, buf: Union[bytes, bytearray]) -> int:
+    def write_crc(self, crc: int, buf: bytes | bytearray) -> int:
         """writes desired data to dfu file"""
         assert self.file_p is not None
         return _write_crc(self.file_p, crc, buf)
@@ -147,7 +373,7 @@ class DfuFile:  # pylint: disable=too-many-instance-attributes, invalid-name
 
 def crc32_byte(accum: int, delta: int):
     """Calculate a 32-bit CRC"""
-    return crc32_table[(accum ^ delta) & 0xff] ^ (accum >> 8)
+    return crc32_table[(accum ^ delta) & 0xFF] ^ (accum >> 8)
 
 
 def _probe_prefix(file: DfuFile):
@@ -156,8 +382,9 @@ def _probe_prefix(file: DfuFile):
     if file.size.total < LMDFU_PREFIX_LENGTH:
         return 1
     if prefix[0] == 0x01 and prefix[1] == 0x00:
-        payload_len = ((prefix[7] << 24) | (prefix[6] << 16)
-                       | (prefix[5] << 8) | prefix[4])
+        payload_len = (
+            (prefix[7] << 24) | (prefix[6] << 16) | (prefix[5] << 8) | prefix[4]
+        )
         expected_payload_len = file.size.total - LMDFU_PREFIX_LENGTH - file.size.suffix
         if payload_len != expected_payload_len:
             return 1
@@ -165,7 +392,7 @@ def _probe_prefix(file: DfuFile):
         file.size.prefix = LMDFU_PREFIX_LENGTH
         file.lmdfu_address = 1024 * ((prefix[3] << 8) | prefix[2])
 
-    elif ((prefix[0] & 0x3f) == 0x1a) and ((prefix[1] & 0x3f) == 0x3f):
+    elif ((prefix[0] & 0x3F) == 0x1A) and ((prefix[1] & 0x3F) == 0x3F):
         file.prefix_type = PrefixType.LPCDFU_UNENCRYPTED_PREFIX
         file.size.prefix = LPCDFU_PREFIX_LENGTH
     if file.size.prefix + file.size.suffix > file.size.total:
@@ -173,7 +400,7 @@ def _probe_prefix(file: DfuFile):
     return 0
 
 
-def _write_crc(f: io.BufferedIOBase, crc: int, buf: Union[bytes, bytearray]) -> int:
+def _write_crc(f: io.BufferedIOBase, crc: int, buf: bytes | bytearray) -> int:
     """writes desired data to dfu file"""
 
     # compute CRC
@@ -196,9 +423,9 @@ def _load_file(file: DfuFile, check_suffix: SuffixReq, check_prefix: PrefixReq) 
     file.size.suffix = 0
 
     file.bcdDFU = 0
-    file.idVendor = 0xffff
-    file.idProduct = 0xffff
-    file.bcdDevice = 0xffff
+    file.idVendor = 0xFFFF
+    file.idProduct = 0xFFFF
+    file.bcdDevice = 0xFFFF
 
     file.lmdfu_address = 0
     if file.name == "-":
@@ -219,7 +446,9 @@ def _load_file(file: DfuFile, check_suffix: SuffixReq, check_prefix: PrefixReq) 
                 file.size.total = len(file.firmware)
         except IOError as e:
             if e.errno == errno.ENOENT:
-                raise NoInputError(f"Could not open file {file.name} for reading") from e
+                raise NoInputError(
+                    f"Could not open file {file.name} for reading"
+                ) from e
             if e.errno == errno.EACCES:
                 raise _IOError(f"Permission denied: {file.name}") from e
             raise _IOError(f"Error reading file {file.name}: {e}") from e
@@ -230,20 +459,20 @@ def _load_file(file: DfuFile, check_suffix: SuffixReq, check_prefix: PrefixReq) 
         missing_suffix = True
     else:
         dfu_suffix = file.firmware[-DFU_SUFFIX_LENGTH:]
-        file.dwCRC = struct.unpack('<I', dfu_suffix[12:])[0]
+        file.dwCRC = struct.unpack("<I", dfu_suffix[12:])[0]
 
-        crc = 0xffffffff
+        crc = 0xFFFFFFFF
         for byte in file.firmware[:-4]:
             crc = crc32_byte(crc, byte)
 
-        if dfu_suffix[8:11] != b'UFD':
+        if dfu_suffix[8:11] != b"UFD":
             reason = "Invalid DFU suffix signature"
             missing_suffix = True
-        elif struct.unpack('<I', dfu_suffix[12:])[0] != crc:
+        elif struct.unpack("<I", dfu_suffix[12:])[0] != crc:
             reason = "DFU suffix CRC does not match"
             missing_suffix = True
         else:
-            file.bcdDFU = struct.unpack('<H', dfu_suffix[6:8])[0]
+            file.bcdDFU = struct.unpack("<H", dfu_suffix[6:8])[0]
             _logger.debug(f"DFU suffix version {file.bcdDFU}")
 
             file.size.suffix = dfu_suffix[11]
@@ -252,9 +481,9 @@ def _load_file(file: DfuFile, check_suffix: SuffixReq, check_prefix: PrefixReq) 
             if file.size.suffix > file.size.total:
                 raise DataError(f"Invalid DFU suffix length {file.size.suffix}")
 
-            file.idVendor = struct.unpack('<H', dfu_suffix[4:6])[0]
-            file.idProduct = struct.unpack('<H', dfu_suffix[2:4])[0]
-            file.bcdDevice = struct.unpack('<H', dfu_suffix[0:2])[0]
+            file.idVendor = struct.unpack("<H", dfu_suffix[4:6])[0]
+            file.idProduct = struct.unpack("<H", dfu_suffix[2:4])[0]
+            file.bcdDevice = struct.unpack("<H", dfu_suffix[0:2])[0]
 
     if missing_suffix:
         assert reason is not None
@@ -264,11 +493,13 @@ def _load_file(file: DfuFile, check_suffix: SuffixReq, check_prefix: PrefixReq) 
             _logger.warning(f"{reason}")
             warnings.warn(
                 "A valid DFU suffix will be required in a future dfu-util release",
-                FutureWarning
+                FutureWarning,
             )
     else:
         if check_suffix == SuffixReq.NO_SUFFIX:
-            raise DataError("Please remove existing DFU suffix before adding a new one.")
+            raise DataError(
+                "Please remove existing DFU suffix before adding a new one."
+            )
 
     res = _probe_prefix(file)
     if (res or file.size.prefix == 0) and check_prefix == PrefixReq.NEEDS_PREFIX:
@@ -278,12 +509,16 @@ def _load_file(file: DfuFile, check_suffix: SuffixReq, check_prefix: PrefixReq) 
     if file.size.prefix:
         data = file.firmware
         if file.prefix_type == PrefixType.LMDFU_PREFIX:
-            _logger.debug(f"Possible TI Stellaris DFU prefix with the following properties\n"
-                          f"Address:        0x{file.lmdfu_address:08x}\n"
-                          f"Payload length: {struct.unpack('<I', data[4:8])[0]}")
+            _logger.debug(
+                f"Possible TI Stellaris DFU prefix with the following properties\n"
+                f"Address:        0x{file.lmdfu_address:08x}\n"
+                f"Payload length: {struct.unpack('<I', data[4:8])[0]}"
+            )
         elif file.prefix_type == PrefixType.LPCDFU_UNENCRYPTED_PREFIX:
-            _logger.debug(f"Possible unencrypted NXP LPC DFU prefix with the following properties\n"
-                         f"Payload length: {struct.unpack('<H', data[2:4])[0] >> 1} kiByte")
+            _logger.debug(
+                f"Possible unencrypted NXP LPC DFU prefix with the following properties\n"
+                f"Payload length: {struct.unpack('<H', data[2:4])[0] >> 1} kiByte"
+            )
         else:
             raise DataError("Unknown DFU prefix type")
 
@@ -292,12 +527,11 @@ def _load_file(file: DfuFile, check_suffix: SuffixReq, check_prefix: PrefixReq) 
 def _store_file(file: DfuFile, write_suffix: bool, write_prefix: bool) -> None:
     """writes suffix and/or prefix to dfu file"""
 
-    crc = 0xffffffff
+    crc = 0xFFFFFFFF
 
     assert file.name is not None
     try:
-        with open(file.name, 'wb') as file.file_p:
-
+        with open(file.name, "wb") as file.file_p:
             # Write prefix, if any
             if write_prefix:
                 if file.prefix_type == PrefixType.LMDFU_PREFIX:
@@ -306,8 +540,8 @@ def _store_file(file: DfuFile, write_suffix: bool, write_prefix: bool) -> None:
 
                     lmdfu_prefix = bytearray(LMDFU_PREFIX_LENGTH)
                     lmdfu_prefix[0] = 0x01  # STELLARIS_DFU_PROG
-                    lmdfu_prefix[2:4] = addr.to_bytes(2, 'little')
-                    lmdfu_prefix[4:8] = len_payload.to_bytes(4, 'little')
+                    lmdfu_prefix[2:4] = addr.to_bytes(2, "little")
+                    lmdfu_prefix[4:8] = len_payload.to_bytes(4, "little")
 
                     crc = _write_crc(file.file_p, crc, lmdfu_prefix)
 
@@ -315,32 +549,35 @@ def _store_file(file: DfuFile, write_suffix: bool, write_prefix: bool) -> None:
                     len_payload = (file.size.total - file.size.suffix + 511) // 512
 
                     lpc_dfu_prefix = bytearray(LPCDFU_PREFIX_LENGTH)
-                    lpc_dfu_prefix[0] = 0x1a  # Unencrypted
-                    lpc_dfu_prefix[1] = 0x3f  # Reserved
-                    lpc_dfu_prefix[2:4] = len_payload.to_bytes(2, 'little')
+                    lpc_dfu_prefix[0] = 0x1A  # Unencrypted
+                    lpc_dfu_prefix[1] = 0x3F  # Reserved
+                    lpc_dfu_prefix[2:4] = len_payload.to_bytes(2, "little")
 
                     for i in range(12, LPCDFU_PREFIX_LENGTH):
-                        lpc_dfu_prefix[i] = 0xff
+                        lpc_dfu_prefix[i] = 0xFF
 
                     crc = _write_crc(file.file_p, crc, lpc_dfu_prefix)
 
             # Write firmware binary
-            crc = _write_crc(file.file_p, crc,
-                             file.firmware[file.size.prefix:file.size.total - file.size.suffix])
+            crc = _write_crc(
+                file.file_p,
+                crc,
+                file.firmware[file.size.prefix : file.size.total - file.size.suffix],
+            )
 
             # Write suffix, if any
             if write_suffix:
                 dfu_suffix = bytearray(16)
-                dfu_suffix[0:2] = file.bcdDevice.to_bytes(2, 'little')
-                dfu_suffix[2:4] = file.idProduct.to_bytes(2, 'little')
-                dfu_suffix[4:6] = file.idVendor.to_bytes(2, 'little')
-                dfu_suffix[6:8] = file.bcdDFU.to_bytes(2, 'little')
-                dfu_suffix[8:11] = b'UFD'
+                dfu_suffix[0:2] = file.bcdDevice.to_bytes(2, "little")
+                dfu_suffix[2:4] = file.idProduct.to_bytes(2, "little")
+                dfu_suffix[4:6] = file.idVendor.to_bytes(2, "little")
+                dfu_suffix[6:8] = file.bcdDFU.to_bytes(2, "little")
+                dfu_suffix[8:11] = b"UFD"
                 dfu_suffix[11] = DFU_SUFFIX_LENGTH
 
                 crc = file.write_crc(crc, dfu_suffix[:-4])
 
-                dfu_suffix[12:16] = crc.to_bytes(4, 'little')
+                dfu_suffix[12:16] = crc.to_bytes(4, "little")
                 _write_crc(file.file_p, crc, dfu_suffix[12:])
 
     except IOError as e:
@@ -355,20 +592,26 @@ def _show_suffix_and_prefix(file: DfuFile) -> None:
     """Prints suffix and prefix of dfu file"""
 
     if file.size.prefix == LMDFU_PREFIX_LENGTH:
-        print(f"The file {file.name} contains a TI Stellaris "
-              f"DFU prefix with the following properties:")
+        print(
+            f"The file {file.name} contains a TI Stellaris "
+            f"DFU prefix with the following properties:"
+        )
         print(f"Address:\t0x{file.lmdfu_address:08x}")
     elif file.size.prefix == LPCDFU_PREFIX_LENGTH:
         prefix = file.firmware
         size_kib = prefix[2] >> 1 | prefix[3] << 7
-        print(f"The file {file.name} contains a NXP unencrypted "
-              f"LPC DFU prefix with the following properties:")
+        print(
+            f"The file {file.name} contains a NXP unencrypted "
+            f"LPC DFU prefix with the following properties:"
+        )
         print(f"Size:\t{size_kib:5} kiB")
     elif file.size.prefix != 0:
         print(f"The file {file.name} contains an unknown prefix")
 
     if file.size.suffix > 0:
-        print(f"The file {file.name} contains a DFU suffix with the following properties:")
+        print(
+            f"The file {file.name} contains a DFU suffix with the following properties:"
+        )
         print(f"BCD device:\t0x{file.bcdDevice:04X}")
         print(f"Product ID:\t0x{file.idProduct:04X}")
         print(f"Vendor ID:\t0x{file.idVendor:04X}")
@@ -378,8 +621,8 @@ def _show_suffix_and_prefix(file: DfuFile) -> None:
 
 
 __all__ = (
-    'DfuFile',
-    'SuffixReq',
-    'PrefixReq',
-    'PrefixType',
+    "DfuFile",
+    "SuffixReq",
+    "PrefixReq",
+    "PrefixType",
 )

--- a/pydfuutil/dfu_load.py
+++ b/pydfuutil/dfu_load.py
@@ -22,6 +22,9 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
+
+from __future__ import annotations
+
 from usb.core import USBError
 from pydfuutil import dfu
 from pydfuutil.dfu_file import DfuFile

--- a/pydfuutil/dfu_util.py
+++ b/pydfuutil/dfu_util.py
@@ -16,9 +16,12 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
+
+from __future__ import annotations
+
 import array
+from collections.abc import Generator, Iterable
 from dataclasses import dataclass
-from typing import Generator, Iterable, Optional
 
 import usb.control
 import usb.core
@@ -33,7 +36,7 @@ from pydfuutil.logger import logger
 from pydfuutil.quirks import get_quirks, QUIRK
 from pydfuutil.usb_dfu import FuncDescriptor, USB_DT_DFU, USB_DT_DFU_SIZE
 
-_logger = logger.getChild('dfu_util')
+_logger = logger.getChild("dfu_util")
 
 MAX_DESC_STR_LEN = 253
 MAX_PATH_LEN = 20
@@ -41,9 +44,12 @@ MAX_PATH_LEN = 20
 
 class DfuUtilMeta(type):
     """DfuUtil MetaDataclass"""
+
     def __repr__(cls):
-        _fields = ', '.join(f'{field}={getattr(cls, field)!r}'
-                            for field in getattr(cls, '__dataclass_fields__'))
+        _fields = ", ".join(
+            f"{field}={getattr(cls, field)!r}"
+            for field in getattr(cls, "__dataclass_fields__")
+        )
         return f"DfuUtil({_fields})"
 
 
@@ -51,8 +57,9 @@ class DfuUtilMeta(type):
 @dataclass
 class DfuUtil(metaclass=DfuUtilMeta):
     """DfuUtil state handle"""
-    dfu_if: Optional[DfuIf] = None
-    match_path: Optional[str] = None
+
+    dfu_if: DfuIf | None = None
+    match_path: str | None = None
     match_vendor: int = -1
     match_product: int = -1
     match_vendor_dfu: int = -1
@@ -61,31 +68,33 @@ class DfuUtil(metaclass=DfuUtilMeta):
     match_iface_index: int = -1
     match_iface_alt_index: int = -1
     match_dev_num: int = -1
-    match_iface_alt_name: Optional[str] = None
-    match_serial: Optional[str] = None
-    match_serial_dfu: Optional[str] = None
+    match_iface_alt_name: str | None = None
+    match_serial: str | None = None
+    match_serial_dfu: str | None = None
 
-    dfu_root: Optional[DfuIf] = None
+    dfu_root: DfuIf | None = None
 
-    path_buf: Optional[str] = None
+    path_buf: str | None = None
 
 
 def cpu_to_le16(value: int) -> bytes:
     """Convert int to uint16le"""
-    return value.to_bytes(2, byteorder='little')
+    return value.to_bytes(2, byteorder="little")
 
 
 def le16_to_cpu(data: bytes) -> int:
     """Convert uint16le to int"""
-    return int.from_bytes(data, byteorder='little')
+    return int.from_bytes(data, byteorder="little")
 
 
-def find_descriptor(desc_list: list[int], desc_type: int, res_buf: bytearray) -> Optional[bytearray]:
+def find_descriptor(
+    desc_list: list[int], desc_type: int, res_buf: bytearray
+) -> bytearray | None:
     """
     Look for a descriptor in a concatenated descriptor list. Will
     return upon the first match of the given descriptor type. Returns length of
     found descriptor, limited to res_size
-    :return: 
+    :return:
     """
     p = 0
     res_size = len(res_buf)
@@ -104,14 +113,14 @@ def find_descriptor(desc_list: list[int], desc_type: int, res_buf: bytearray) ->
                 desc_len = res_size
             if p + desc_len > list_len:
                 desc_len = list_len - p
-            res_buf[:] = desc_list[p:p + desc_len]
+            res_buf[:] = desc_list[p : p + desc_len]
             return res_buf
         p += desc_list[p]
 
     return None
 
 
-def get_path(dev) -> Optional[str]:
+def get_path(dev) -> str | None:
     """Get device bus/port path"""
     path = None
     try:
@@ -123,10 +132,10 @@ def get_path(dev) -> Optional[str]:
         path = f"{bus_num}-{device_num}"
 
         # If the device supports port numbers, get them
-        if hasattr(dev, 'port_numbers'):
+        if hasattr(dev, "port_numbers"):
             port_nums = dev.port_numbers
             if port_nums is not None:
-                path += '.' + '.'.join(map(str, port_nums))
+                path += "." + ".".join(map(str, port_nums))
 
     except (TypeError, ValueError) as e:
         # Handle any exceptions, like if the device does not support port numbers
@@ -168,13 +177,15 @@ def disconnect_devices() -> None:
 
 def print_dfu_if(dfu_if: DfuIf) -> None:
     """Print dfu interface"""
-    print(f"Found {'DFU' if dfu_if.flags & IFF.DFU else 'Runtime'}: "
-          f'[{dfu_if.vendor:04x}:{dfu_if.product:04x}] '
-          f'ver={dfu_if.bcdDevice:04x}, devnum={dfu_if.devnum}, '
-          f'cfg={dfu_if.configuration}, intf={dfu_if.interface}, '
-          f'path="{get_path(dfu_if.dev)}", '
-          f'alt={dfu_if.altsetting}, name="{dfu_if.alt_name}", '
-          f'serial="{dfu_if.serial_name}"')
+    print(
+        f"Found {'DFU' if dfu_if.flags & IFF.DFU else 'Runtime'}: "
+        f"[{dfu_if.vendor:04x}:{dfu_if.product:04x}] "
+        f"ver={dfu_if.bcdDevice:04x}, devnum={dfu_if.devnum}, "
+        f"cfg={dfu_if.configuration}, intf={dfu_if.interface}, "
+        f'path="{get_path(dfu_if.dev)}", '
+        f'alt={dfu_if.altsetting}, name="{dfu_if.alt_name}", '
+        f'serial="{dfu_if.serial_name}"'
+    )
 
 
 # Walk the device tree and print out DFU devices
@@ -187,13 +198,15 @@ def list_dfu_interfaces() -> None:
 
 
 def get_altsettings(
-        config: usb.core.Configuration,
-        interface: int) -> Generator[usb.core.Interface, None, None]:
+    config: usb.core.Configuration, interface: int
+) -> Generator[usb.core.Interface, None, None]:
     """Get the alternate settings of the interface"""
     return usb.util.find_descriptor(config, find_all=True, bInterfaceNumber=interface)
 
 
-def _found_dfu(dev: usb.core.Device, cfg: usb.core.Configuration, func_dfu: FuncDescriptor) -> None:
+def _found_dfu(
+    dev: usb.core.Device, cfg: usb.core.Configuration, func_dfu: FuncDescriptor
+) -> None:
     """Found dfu interface"""
     if func_dfu.bLength == 7:
         _logger.info("Deducing device DFU version from functional descriptor length")
@@ -212,9 +225,7 @@ def _found_dfu(dev: usb.core.Device, cfg: usb.core.Configuration, func_dfu: Func
     except USBError as e:
         raise _IOError(e) from e
     for uif in cfg:
-
-        if (DfuUtil.match_iface_index > -1
-                and DfuUtil.match_iface_index != uif.index):
+        if DfuUtil.match_iface_index > -1 and DfuUtil.match_iface_index != uif.index:
             continue
 
         if not uif:
@@ -225,51 +236,62 @@ def _found_dfu(dev: usb.core.Device, cfg: usb.core.Configuration, func_dfu: Func
         multiple_alt = len(altsetting) > 0
 
         for alt in altsetting:
-
             quirks = get_quirks(dev.idVendor, dev.idProduct, dev.bcdDevice)
 
             intf = alt
 
             # DFU subclass
-            if intf.bInterfaceClass != 0xfe or intf.bInterfaceSubClass != 1:
+            if intf.bInterfaceClass != 0xFE or intf.bInterfaceSubClass != 1:
                 continue
 
             dfu_mode = intf.bInterfaceProtocol == 2
 
             # ST DfuSe devices often use bInterfaceProtocol 0 instead of 2
-            if func_dfu.bcdDFUVersion == 0x011a and intf.bInterfaceProtocol == 0:
+            if func_dfu.bcdDFUVersion == 0x011A and intf.bInterfaceProtocol == 0:
                 dfu_mode = True
 
             # LPC DFU bootloader has bInterfaceProtocol 1 (Runtime) instead of 2
-            if (dev.idVendor == 0x1fc9 and dev.idProduct == 0x000c
-                    and intf.bInterfaceProtocol == 1):
+            if (
+                dev.idVendor == 0x1FC9
+                and dev.idProduct == 0x000C
+                and intf.bInterfaceProtocol == 1
+            ):
                 dfu_mode = True
 
             # Old Jabra devices may have bInterfaceProtocol 0 instead of 2.
             # Also, runtime PID and DFU pid are the same.
             # In DFU mode, the configuration descriptor has only 1 interface.
-            if (dev.idVendor == 0x0b0e
-                    and intf.bInterfaceProtocol == 0
-                    and cfg.bNumInterfaces == 1):
+            if (
+                dev.idVendor == 0x0B0E
+                and intf.bInterfaceProtocol == 0
+                and cfg.bNumInterfaces == 1
+            ):
                 dfu_mode = True
 
-            if (dfu_mode
-                    and DfuUtil.match_iface_alt_index > -1
-                    and DfuUtil.match_iface_alt_index != intf.bAlternateSetting):
+            if (
+                dfu_mode
+                and DfuUtil.match_iface_alt_index > -1
+                and DfuUtil.match_iface_alt_index != intf.bAlternateSetting
+            ):
                 continue
 
             if dfu_mode:
-                if ((DfuUtil.match_vendor_dfu >= 0
-                     and DfuUtil.match_vendor_dfu != dev.idVendor) or
-                        (DfuUtil.match_product_dfu >= 0
-                         and DfuUtil.match_product_dfu != dev.idProduct)):
+                if (
+                    DfuUtil.match_vendor_dfu >= 0
+                    and DfuUtil.match_vendor_dfu != dev.idVendor
+                ) or (
+                    DfuUtil.match_product_dfu >= 0
+                    and DfuUtil.match_product_dfu != dev.idProduct
+                ):
                     continue
 
             else:
-                if ((DfuUtil.match_vendor >= 0
-                     and DfuUtil.match_vendor != dev.idVendor) or
-                        (DfuUtil.match_product >= 0
-                         and DfuUtil.match_product != dev.idProduct)):
+                if (
+                    DfuUtil.match_vendor >= 0 and DfuUtil.match_vendor != dev.idVendor
+                ) or (
+                    DfuUtil.match_product >= 0
+                    and DfuUtil.match_product != dev.idProduct
+                ):
                     continue
 
             if DfuUtil.match_dev_num >= 0 and DfuUtil.match_dev_num != dev.address:
@@ -288,7 +310,7 @@ def _found_dfu(dev: usb.core.Device, cfg: usb.core.Configuration, func_dfu: Func
                     if quirks & QUIRK.UTF8_SERIAL:
                         serial_name = usb.util.get_string(dev, dev.iSerialNumber)
                         if serial_name:
-                            serial_name += '0'
+                            serial_name += "0"
                     else:
                         serial_name = usb.util.get_string(dev, dev.iSerialNumber)
                 except USBError as e:
@@ -299,17 +321,22 @@ def _found_dfu(dev: usb.core.Device, cfg: usb.core.Configuration, func_dfu: Func
             if not serial_name:
                 serial_name = "UNKNOWN"
 
-            if (dfu_mode
-                    and DfuUtil.match_iface_alt_name is not None
-                    and alt_name != DfuUtil.match_iface_alt_name):
+            if (
+                dfu_mode
+                and DfuUtil.match_iface_alt_name is not None
+                and alt_name != DfuUtil.match_iface_alt_name
+            ):
                 continue
 
             if dfu_mode:
-                if (DfuUtil.match_serial_dfu is not None
-                        and DfuUtil.match_serial_dfu != serial_name):
+                if (
+                    DfuUtil.match_serial_dfu is not None
+                    and DfuUtil.match_serial_dfu != serial_name
+                ):
                     continue
-            elif (DfuUtil.match_serial is not None
-                  and DfuUtil.match_serial != serial_name):
+            elif (
+                DfuUtil.match_serial is not None and DfuUtil.match_serial != serial_name
+            ):
                 continue
 
             pdfu = DfuIf(
@@ -331,8 +358,9 @@ def _found_dfu(dev: usb.core.Device, cfg: usb.core.Configuration, func_dfu: Func
 
             pdfu.flags |= dfu.IFF.DFU if dfu_mode else 0
             pdfu.flags |= dfu.IFF.ALT if multiple_alt else 0
-            func_dfu.bcdDFUVersion = (0x0110 if quirks & QUIRK.FORCE_DFU11
-                                      else func_dfu.bcdDFUVersion)
+            func_dfu.bcdDFUVersion = (
+                0x0110 if quirks & QUIRK.FORCE_DFU11 else func_dfu.bcdDFUVersion
+            )
 
             # append to list
             if DfuUtil.dfu_root is None:
@@ -353,13 +381,15 @@ def probe_configuration(dev: usb.core.Device) -> None:
         raise _IOError(e) from e
 
     for cfg in cfgs:
-
-        if (DfuUtil.match_config_index > -1
-                and DfuUtil.match_config_index != cfg.bConfigurationValue):
+        if (
+            DfuUtil.match_config_index > -1
+            and DfuUtil.match_config_index != cfg.bConfigurationValue
+        ):
             continue
 
-        if ret := find_descriptor(cfg.extra_descriptors, USB_DT_DFU,
-                                  bytearray(USB_DT_DFU_SIZE)):
+        if ret := find_descriptor(
+            cfg.extra_descriptors, USB_DT_DFU, bytearray(USB_DT_DFU_SIZE)
+        ):
             func_dfu = FuncDescriptor.from_bytes(ret)
             _found_dfu(dev, cfg, func_dfu)
             continue
@@ -374,12 +404,12 @@ def probe_configuration(dev: usb.core.Device) -> None:
             for alt in get_altsettings(cfg, uif.bInterfaceNumber):
                 intf = alt
 
-                if intf.bInterfaceClass != 0xfe or intf.bInterfaceSubClass != 1:
+                if intf.bInterfaceClass != 0xFE or intf.bInterfaceSubClass != 1:
                     continue
 
-                if ret := find_descriptor(intf.extra_descriptors,
-                                          USB_DT_DFU,
-                                          bytearray(USB_DT_DFU_SIZE)):
+                if ret := find_descriptor(
+                    intf.extra_descriptors, USB_DT_DFU, bytearray(USB_DT_DFU_SIZE)
+                ):
                     func_dfu = FuncDescriptor.from_bytes(ret)
                     # goto found_dfu
                     _found_dfu(dev, cfg, func_dfu)
@@ -408,34 +438,32 @@ def probe_configuration(dev: usb.core.Device) -> None:
                 continue
             except USBError as e:
                 _logger.debug(e)
-            _logger.warning("Device has DFU interface, "
-                            "but has no DFU functional descriptor")
+            _logger.warning(
+                "Device has DFU interface, but has no DFU functional descriptor"
+            )
 
             # fake version 1.0
-            func_dfu = FuncDescriptor(
-                bLength=7,
-                bcdDFUVersion=0x0100
-            )
+            func_dfu = FuncDescriptor(bLength=7, bcdDFUVersion=0x0100)
 
             # goto found_dfu
             _found_dfu(dev, cfg, func_dfu)
 
 
 __all__ = (
-    'IFF',
-    'DfuUtil',
-    'MAX_DESC_STR_LEN',
-    'probe_devices',
-    'disconnect_devices',
-    'print_dfu_if',
-    'list_dfu_interfaces',
+    "IFF",
+    "DfuUtil",
+    "MAX_DESC_STR_LEN",
+    "probe_devices",
+    "disconnect_devices",
+    "print_dfu_if",
+    "list_dfu_interfaces",
 )
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import logging
 
     _logger.setLevel(logging.DEBUG)
-    _ctx = usb.core.find(find_all=True, idVendor=0x1fc9)
+    _ctx = usb.core.find(find_all=True, idVendor=0x1FC9)
     probe_devices(_ctx)
     list_dfu_interfaces()
     disconnect_devices()

--- a/pydfuutil/dfuse.py
+++ b/pydfuutil/dfuse.py
@@ -17,11 +17,13 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
+
+from __future__ import annotations
+
 import argparse
 import logging
 from dataclasses import dataclass
 from enum import Enum, IntFlag
-from typing import Optional, Union
 
 import usb.util
 from usb.core import USBError
@@ -30,21 +32,26 @@ from usb.backend.libusb1 import LIBUSB_ERROR_PIPE
 from pydfuutil import dfu
 from pydfuutil.dfu_file import DfuFile
 from pydfuutil.dfuse_mem import find_segment, DFUSE, parse_memory_layout
-from pydfuutil.exceptions import (UsageError, _IOError, DataError, ProtocolError,
-                                  SoftwareError, except_and_safe_exit)
+from pydfuutil.exceptions import (
+    UsageError,
+    _IOError,
+    DataError,
+    ProtocolError,
+    SoftwareError,
+    except_and_safe_exit,
+)
 from pydfuutil.logger import logger
 from pydfuutil.portable import milli_sleep
 from pydfuutil.progress import Progress
 from pydfuutil.quirks import QUIRK, fixup_dfuse_layout
 
-_logger = logger.getChild('dfuse')
+_logger = logger.getChild("dfuse")
 
 TIMEOUT = 5000
 
 
 @dataclass
 class RuntimeOptions:
-
     class Flags(IntFlag):
         none = 0
         address_present = 1
@@ -55,9 +62,9 @@ class RuntimeOptions:
         force = 32
         fast = 64
 
-    address: Optional[int] = None
+    address: int | None = None
     flags: Flags = Flags.none
-    length: Optional[int] = None
+    length: int | None = None
     last_erased_page: int = 1
 
     def __bool__(self):
@@ -66,39 +73,44 @@ class RuntimeOptions:
 
 class Command(Enum):
     """DFUSE commands"""
+
     SET_ADDRESS = 0x1
     ERASE_PAGE = 0x2
     MASS_ERASE = 0x3
     READ_UNPROTECT = 0x4
 
 
-def quad2uint(p: Union[bytes, bytearray]) -> int:
+def quad2uint(p: bytes | bytearray) -> int:
     """
     Convert a 4-byte sequence into an unsigned integer (little-endian).
     :param p: 4-byte sequence
     :return: Converted unsigned integer
     """
-    return int.from_bytes(p, byteorder='little', signed=False)
+    return int.from_bytes(p, byteorder="little", signed=False)
 
 
 def add_cli_options(parser):
     class ColonSplitAction(argparse.Action):
         def __call__(self, parser, namespace, values, option_string=None):
-            setattr(namespace, self.dest, values.split(':'))
+            setattr(namespace, self.dest, values.split(":"))
 
-    parser.add_argument('-s', '--dfuse-address',
-                        dest='dfuse_address', metavar='<address><:...>',
-                        action=ColonSplitAction,
-                        help="ST DfuSe mode string, specifying target\n"
-                             "address for raw file download or upload\n"
-                             "(not applicable for DfuSe file (.dfu) downloads).\n"
-                             "Add more DfuSe options separated with ':'\n\n"
-                             'leave\n\tLeave DFU mode (jump to application)\n'
-                             'mass-erase\n\tErase the whole device (requires "force")\n'
-                             'unprotect\n\tErase read protected device (requires "force")\n'
-                             'will-reset\n\tExpect device to reset (e.g. option bytes write)\n'
-                             'force\n\tYou really know what you are doing!\n'
-                             '<length>\n\tLength of firmware to upload from device')
+    parser.add_argument(
+        "-s",
+        "--dfuse-address",
+        dest="dfuse_address",
+        metavar="<address><:...>",
+        action=ColonSplitAction,
+        help="ST DfuSe mode string, specifying target\n"
+        "address for raw file download or upload\n"
+        "(not applicable for DfuSe file (.dfu) downloads).\n"
+        "Add more DfuSe options separated with ':'\n\n"
+        "leave\n\tLeave DFU mode (jump to application)\n"
+        'mass-erase\n\tErase the whole device (requires "force")\n'
+        'unprotect\n\tErase read protected device (requires "force")\n'
+        "will-reset\n\tExpect device to reset (e.g. option bytes write)\n"
+        "force\n\tYou really know what you are doing!\n"
+        "<length>\n\tLength of firmware to upload from device",
+    )
 
 
 @except_and_safe_exit(_logger)
@@ -109,7 +121,7 @@ def parse_options(dfuse_opts: list[str]) -> RuntimeOptions:
 
     def atoi(string: str):
         try:
-            if string.startswith('0x'):
+            if string.startswith("0x"):
                 return int(string, 16)
             else:
                 return int(string)
@@ -117,7 +129,7 @@ def parse_options(dfuse_opts: list[str]) -> RuntimeOptions:
             return None
 
     if opts is not None and len(opts) > 0:
-        if opts[0] == '':
+        if opts[0] == "":
             opts.pop(0)
         else:
             address = atoi(opts[0])
@@ -131,7 +143,7 @@ def parse_options(dfuse_opts: list[str]) -> RuntimeOptions:
     # Parse other options if any
     for opt in ("force", "leave", "mass-erase", "unprotect", "will-reset", "fast"):
         if opt in opts:
-            rt_opts.flags |= RuntimeOptions.Flags[opt.replace('-', '_')]
+            rt_opts.flags |= RuntimeOptions.Flags[opt.replace("-", "_")]
             opts.pop(opts.index(opt))
 
     if len(opts) > 1:
@@ -159,21 +171,23 @@ def upload(dif: dfu.DfuIf, length: int, transaction: int) -> bytes:
     assert dev is not None
     assert dif.interface is not None
     status = dev.ctrl_transfer(
-        bmRequestType=usb.util.ENDPOINT_IN |
-                      usb.util.CTRL_TYPE_CLASS |
-                      usb.util.CTRL_RECIPIENT_INTERFACE,
+        bmRequestType=usb.util.ENDPOINT_IN
+        | usb.util.CTRL_TYPE_CLASS
+        | usb.util.CTRL_RECIPIENT_INTERFACE,
         bRequest=dfu.Request.UPLOAD,
         wValue=transaction,
         wIndex=dif.interface,
         data_or_wLength=length,
-        timeout=TIMEOUT
+        timeout=TIMEOUT,
     )
     assert not isinstance(status, int)
 
     return status.tobytes()
 
 
-def download(dif: dfu.DfuIf, data: Optional[Union[bytes, bytearray]], transaction: int) -> int:
+def download(
+    dif: dfu.DfuIf, data: bytes | bytearray | None, transaction: int
+) -> int:
     """
     Download request for DfuSe 1.1a
 
@@ -186,31 +200,35 @@ def download(dif: dfu.DfuIf, data: Optional[Union[bytes, bytearray]], transactio
     assert dev is not None
     assert dif.interface is not None
     status = dev.ctrl_transfer(
-        bmRequestType=usb.util.ENDPOINT_OUT |
-                      usb.util.CTRL_TYPE_CLASS |
-                      usb.util.CTRL_RECIPIENT_INTERFACE,
+        bmRequestType=usb.util.ENDPOINT_OUT
+        | usb.util.CTRL_TYPE_CLASS
+        | usb.util.CTRL_RECIPIENT_INTERFACE,
         bRequest=dfu.Request.DNLOAD,
         wValue=transaction,
         wIndex=dif.interface,
         data_or_wLength=data,
-        timeout=TIMEOUT
+        timeout=TIMEOUT,
     )
     assert isinstance(status, int)
 
     if status < 0:
         # Silently fail on leave request on some unpredictable devices
-        if dif.quirks and dif.quirks & QUIRK.DFUSE_LEAVE and not data and transaction == 2:
+        if (
+            dif.quirks
+            and dif.quirks & QUIRK.DFUSE_LEAVE
+            and not data
+            and transaction == 2
+        ):
             return status
-        _logger.warning(
-            f"download: libusb_control_transfer returned {status}"
-        )
+        _logger.warning(f"download: libusb_control_transfer returned {status}")
 
     return status
 
 
 @except_and_safe_exit(_logger)
-def special_command(dif: dfu.DfuIf, address: int,
-                    command: Command, rt_opts: RuntimeOptions) -> int:
+def special_command(
+    dif: dfu.DfuIf, address: int, command: Command, rt_opts: RuntimeOptions
+) -> int:
     """
     Perform DfuSe-specific commands.
     Leaves the device in dfuDNLOAD-IDLE state
@@ -237,7 +255,8 @@ def special_command(dif: dfu.DfuIf, address: int,
         page_size = segment.pagesize
         _logger.debug(
             f"Erasing page size {page_size} at address 0x{address:08x}, "
-            f"page starting at 0x{address & ~(page_size - 1):08x}")
+            f"page starting at 0x{address & ~(page_size - 1):08x}"
+        )
         buf[0], length = 0x41, 5  # Erase command
         rt_opts.last_erased_page = address & ~(page_size - 1)
     elif command == Command.SET_ADDRESS:
@@ -250,15 +269,17 @@ def special_command(dif: dfu.DfuIf, address: int,
     else:
         raise UsageError(f"Non-supported special command {command}")
 
-    buf[1] = address & 0xff
-    buf[2] = (address >> 8) & 0xff
-    buf[3] = (address >> 16) & 0xff
-    buf[4] = (address >> 24) & 0xff
+    buf[1] = address & 0xFF
+    buf[2] = (address >> 8) & 0xFF
+    buf[3] = (address >> 16) & 0xFF
+    buf[4] = (address >> 24) & 0xFF
 
     try:
         ret = download(dif, buf[:length], 0)
     except USBError as e:
-        raise _IOError(f"Error during special command {command.name} download: {e}") from e
+        raise _IOError(
+            f"Error during special command {command.name} download: {e}"
+        ) from e
 
     while True:
         try:
@@ -269,7 +290,11 @@ def special_command(dif: dfu.DfuIf, address: int,
             # with many bootloaders
             poll_timeout = dst.bwPollTimeout
         except USBError as e:
-            if e.backend_error_code == LIBUSB_ERROR_PIPE  and poll_timeout != 0 and stalls < 3:
+            if (
+                e.backend_error_code == LIBUSB_ERROR_PIPE
+                and poll_timeout != 0
+                and stalls < 3
+            ):
                 # Keep the existing dst (bwPollTimeout etc. from the last successful
                 # poll) untouched, only mark it busy - matching C, which leaves the
                 # dfu_status struct as-is across a stalled poll.
@@ -277,29 +302,43 @@ def special_command(dif: dfu.DfuIf, address: int,
                 stalls += 1
                 _logger.debug("* Device stalled USB pipe, reusing last poll timeout")
             elif e.backend_error_code is not None and e.backend_error_code < 0:
-                raise _IOError(f"Error during special command {command.name} get_status: {e}")
+                raise _IOError(
+                    f"Error during special command {command.name} get_status: {e}"
+                )
             else:
-                raise _IOError(f"Error during special command {command.name} get_status: {e}")
+                raise _IOError(
+                    f"Error during special command {command.name} get_status: {e}"
+                )
 
         if first_poll:
             first_poll = 0
-            if (dst.bState != dfu.State.DFU_DOWNLOAD_BUSY
-                    and dst.bState != dfu.State.DFU_DOWNLOAD_IDLE):
-                _logger.error(f"DFU state({dst.bState}) = {dst.bState.to_string()}, "
-                              f"status({dst.bStatus}) = {dst.bStatus.to_string()}")
-                raise ProtocolError(f"Wrong state after command {command.name} download")
+            if (
+                dst.bState != dfu.State.DFU_DOWNLOAD_BUSY
+                and dst.bState != dfu.State.DFU_DOWNLOAD_IDLE
+            ):
+                _logger.error(
+                    f"DFU state({dst.bState}) = {dst.bState.to_string()}, "
+                    f"status({dst.bStatus}) = {dst.bStatus.to_string()}"
+                )
+                raise ProtocolError(
+                    f"Wrong state after command {command.name} download"
+                )
             # STM32F405 lies about mass erase timeout
             if command == Command.MASS_ERASE and dst.bwPollTimeout == 100:
                 poll_timeout = 35000  # Datasheet says up to 32 seconds
                 _logger.info("Setting timeout to 35 seconds")
 
-        _logger.debug(f"Err: Poll timeout {poll_timeout} "
-                      f"ms on command {command.name} (state={dst.bState.to_string()})")
+        _logger.debug(
+            f"Err: Poll timeout {poll_timeout} "
+            f"ms on command {command.name} (state={dst.bState.to_string()})"
+        )
         # A non-null bwPollTimeout for SET_ADDRESS seems a common bootloader bug
         if command == Command.SET_ADDRESS:
             poll_timeout = 0
-        if (not rt_opts.flags & RuntimeOptions.Flags.fast
-                and dst.bState == dfu.State.DFU_DOWNLOAD_BUSY):
+        if (
+            not rt_opts.flags & RuntimeOptions.Flags.fast
+            and dst.bState == dfu.State.DFU_DOWNLOAD_BUSY
+        ):
             milli_sleep(poll_timeout)
         if command == Command.READ_UNPROTECT:
             return ret
@@ -321,8 +360,9 @@ def special_command(dif: dfu.DfuIf, address: int,
 
 
 @except_and_safe_exit(_logger)
-def download_chunk(dif: dfu.DfuIf, data: bytes, size: int,
-                   transaction: int, rt_opts: RuntimeOptions) -> int:
+def download_chunk(
+    dif: dfu.DfuIf, data: bytes, size: int, transaction: int, rt_opts: RuntimeOptions
+) -> int:
     """
     Download a chunk of data during DFU download operation.
 
@@ -361,15 +401,24 @@ def download_chunk(dif: dfu.DfuIf, data: bytes, size: int,
             else:
                 raise _IOError(f"Error during download get_status {e}")
 
-        _logger.debug(f"Err: Poll timeout {dst.bwPollTimeout} "
-                      f"ms on download (state={dst.bState.to_string()})")
-        if not rt_opts.flags & RuntimeOptions.Flags.fast and dst.bState == dfu.State.DFU_DOWNLOAD_BUSY:
+        _logger.debug(
+            f"Err: Poll timeout {dst.bwPollTimeout} "
+            f"ms on download (state={dst.bState.to_string()})"
+        )
+        if (
+            not rt_opts.flags & RuntimeOptions.Flags.fast
+            and dst.bState == dfu.State.DFU_DOWNLOAD_BUSY
+        ):
             milli_sleep(dst.bwPollTimeout)
 
         if dst.bState in (
-                dfu.State.DFU_DOWNLOAD_IDLE, dfu.State.DFU_ERROR, dfu.State.DFU_MANIFEST
-        ) or (rt_opts.flags & RuntimeOptions.Flags.will_reset
-              and dst.bState == dfu.State.DFU_DOWNLOAD_BUSY):
+            dfu.State.DFU_DOWNLOAD_IDLE,
+            dfu.State.DFU_ERROR,
+            dfu.State.DFU_MANIFEST,
+        ) or (
+            rt_opts.flags & RuntimeOptions.Flags.will_reset
+            and dst.bState == dfu.State.DFU_DOWNLOAD_BUSY
+        ):
             break
 
     if dst.bState == dfu.State.DFU_MANIFEST:
@@ -377,8 +426,10 @@ def download_chunk(dif: dfu.DfuIf, data: bytes, size: int,
 
     if dst.bStatus != dfu.Status.OK:
         _logger.error("Failed!")
-        _logger.error(f"DFU state{dst.bState} = {dst.bState.to_string()},"
-                      f"status{dst.bStatus} = {dst.bStatus.to_string()}")
+        _logger.error(
+            f"DFU state{dst.bState} = {dst.bState.to_string()},"
+            f"status{dst.bStatus} = {dst.bStatus.to_string()}"
+        )
         return -1
 
     return bytes_sent
@@ -407,8 +458,9 @@ def do_leave(dif: dfu.DfuIf, rt_opts: RuntimeOptions) -> None:
 
 
 @except_and_safe_exit(_logger)
-def do_upload(dif: dfu.DfuIf, xfer_size: int, file: DfuFile,
-              dfuse_opts: RuntimeOptions) -> int:
+def do_upload(
+    dif: dfu.DfuIf, xfer_size: int, file: DfuFile, dfuse_opts: RuntimeOptions
+) -> int:
     total_bytes = 0
     upload_limit = 0
     ret = 0
@@ -426,13 +478,17 @@ def do_upload(dif: dfu.DfuIf, xfer_size: int, file: DfuFile,
 
         assert rt_opts.address is not None
         segment = find_segment(mem_layout, rt_opts.address)
-        if not rt_opts.flags & RuntimeOptions.Flags.force and (not segment or not (segment.mem_type & DFUSE.READABLE)):
+        if not rt_opts.flags & RuntimeOptions.Flags.force and (
+            not segment or not (segment.mem_type & DFUSE.READABLE)
+        ):
             raise UsageError(f"Page at 0x{rt_opts.address:08x} is not readable")
 
         if not upload_limit:
             if segment:
                 upload_limit = segment.end - rt_opts.address + 1
-                _logger.info(f"Limiting upload to end of memory segment, {upload_limit} bytes")
+                _logger.info(
+                    f"Limiting upload to end of memory segment, {upload_limit} bytes"
+                )
             else:
                 # unknown segment - i.e. "force" has been used
                 upload_limit = 0x4000
@@ -490,12 +546,14 @@ def do_upload(dif: dfu.DfuIf, xfer_size: int, file: DfuFile,
 # returns 0 on success, otherwise -EINVAL
 # pylint: disable=invalid-name
 @except_and_safe_exit(_logger)
-def download_element(dif: dfu.DfuIf,
-                     dw_element_address: int,
-                     dw_element_size: int,
-                     data: bytes,
-                     xfer_size: int,
-                     rt_opts: RuntimeOptions) -> int:
+def download_element(
+    dif: dfu.DfuIf,
+    dw_element_address: int,
+    dw_element_size: int,
+    data: bytes,
+    xfer_size: int,
+    rt_opts: RuntimeOptions,
+) -> int:
     """
     Download an element in DFU.
 
@@ -511,7 +569,8 @@ def download_element(dif: dfu.DfuIf,
     # Check at least that we can write to the last address
     segment = find_segment(dif.mem_layout, dw_element_address + dw_element_size - 1)
     if not rt_opts.flags & RuntimeOptions.Flags.force and (
-            not segment or not segment.mem_type & DFUSE.WRITEABLE):
+        not segment or not segment.mem_type & DFUSE.WRITEABLE
+    ):
         raise UsageError(
             f"Error: Last page at 0x{dw_element_address + dw_element_size - 1:08x} "
             f"is not writeable"
@@ -524,7 +583,9 @@ def download_element(dif: dfu.DfuIf,
         chunk_size = xfer_size
 
         segment = find_segment(dif.mem_layout, address)
-        if not rt_opts.flags & RuntimeOptions.Flags.force and (not segment or not segment.mem_type & DFUSE.WRITEABLE):
+        if not rt_opts.flags & RuntimeOptions.Flags.force and (
+            not segment or not segment.mem_type & DFUSE.WRITEABLE
+        ):
             raise UsageError(f"Page at 0x{address:08x} is not writeable")
 
         # If the location is not in the memory map we skip erasing
@@ -539,16 +600,22 @@ def download_element(dif: dfu.DfuIf,
             chunk_size = dw_element_size - p
 
         # Erase only for flash memory downloads
-        if (segment.mem_type & DFUSE.ERASABLE
-                and not rt_opts.flags & RuntimeOptions.Flags.mass_erase):
+        if (
+            segment.mem_type & DFUSE.ERASABLE
+            and not rt_opts.flags & RuntimeOptions.Flags.mass_erase
+        ):
             # erase all involved pages
             for erase_address in range(address, address + chunk_size, page_size):
                 if (erase_address & ~(page_size - 1)) != rt_opts.last_erased_page:
                     special_command(dif, erase_address, Command.ERASE_PAGE, rt_opts)
 
-            if (address + chunk_size - 1) & ~(page_size - 1) != rt_opts.last_erased_page:
+            if (address + chunk_size - 1) & ~(
+                page_size - 1
+            ) != rt_opts.last_erased_page:
                 _logger.debug("Err: Chunk extends into next page, erase it as well")
-                special_command(dif, address + chunk_size - 1, Command.ERASE_PAGE, rt_opts)
+                special_command(
+                    dif, address + chunk_size - 1, Command.ERASE_PAGE, rt_opts
+                )
 
             # dfu_progress_bar("Erase   ", p, dwElementSize);
 
@@ -565,8 +632,10 @@ def download_element(dif: dfu.DfuIf,
             chunk_size = dw_element_size - p
 
         if _logger.level == logging.DEBUG:
-            _logger.debug(f"Err: Download from image offset 0x{p:08x} to memory "
-                          f"0x{address:08x}-0x{address + chunk_size - 1:08x}, size {chunk_size}")
+            _logger.debug(
+                f"Err: Download from image offset 0x{p:08x} to memory "
+                f"0x{address:08x}-0x{address + chunk_size - 1:08x}, size {chunk_size}"
+            )
         else:
             ...
             # dfu_progress_bar("Download", p, dwElementSize);
@@ -574,7 +643,7 @@ def download_element(dif: dfu.DfuIf,
         special_command(dif, address, Command.SET_ADDRESS, rt_opts)
 
         # transaction = 2 for no address offset
-        ret = download_chunk(dif, data[p:p + chunk_size], chunk_size, 2, rt_opts)
+        ret = download_chunk(dif, data[p : p + chunk_size], chunk_size, 2, rt_opts)
         if ret != chunk_size:
             raise _IOError(f"Failed to write whole chunk: {ret} of {chunk_size} bytes")
 
@@ -585,7 +654,9 @@ def download_element(dif: dfu.DfuIf,
 @except_and_safe_exit(_logger)
 def dfuse_memcpy(dst, src, rem, size):
     if size > rem:
-        raise DataError("Corrupt DfuSe file: Cannot read {} bytes from {} bytes".format(size, rem))
+        raise DataError(
+            "Corrupt DfuSe file: Cannot read {} bytes from {} bytes".format(size, rem)
+        )
 
     if dst is not None:
         dst.extend(src[:size])
@@ -596,9 +667,13 @@ def dfuse_memcpy(dst, src, rem, size):
 
 
 @except_and_safe_exit(_logger)
-def do_bin_download(dif: dfu.DfuIf, xfer_size: int,
-                    file: DfuFile, start_address: int,
-                    rt_opts: RuntimeOptions) -> int:
+def do_bin_download(
+    dif: dfu.DfuIf,
+    xfer_size: int,
+    file: DfuFile,
+    start_address: int,
+    rt_opts: RuntimeOptions,
+) -> int:
     """
     Download raw binary file to DfuSe device.
 
@@ -612,12 +687,16 @@ def do_bin_download(dif: dfu.DfuIf, xfer_size: int,
     dw_element_address = start_address
     dw_element_size = file.size.total - file.size.suffix - file.size.prefix
 
-    _logger.info(f"Downloading element to "
-                 f"address = 0x{dw_element_address:08x}, size = {dw_element_size}")
+    _logger.info(
+        f"Downloading element to "
+        f"address = 0x{dw_element_address:08x}, size = {dw_element_size}"
+    )
 
-    data = file.firmware[file.size.prefix:]
+    data = file.firmware[file.size.prefix :]
 
-    ret = download_element(dif, dw_element_address, dw_element_size, data, xfer_size, rt_opts)
+    ret = download_element(
+        dif, dw_element_address, dw_element_size, data, xfer_size, rt_opts
+    )
     if ret == 0:
         _logger.info("File downloaded successfully")
 
@@ -625,8 +704,9 @@ def do_bin_download(dif: dfu.DfuIf, xfer_size: int,
 
 
 @except_and_safe_exit(_logger)
-def do_dfuse_download(dif: dfu.DfuIf, xfer_size: int,
-                      file: DfuFile, rt_opts: RuntimeOptions) -> int:
+def do_dfuse_download(
+    dif: dfu.DfuIf, xfer_size: int, file: DfuFile, rt_opts: RuntimeOptions
+) -> int:
     dfu_prefix = bytearray(11)
     target_prefix = bytearray(274)
     element_header = bytearray(8)
@@ -640,7 +720,7 @@ def do_dfuse_download(dif: dfu.DfuIf, xfer_size: int,
 
     rem = dfuse_memcpy(dfu_prefix, file.firmware, rem, len(dfu_prefix))
 
-    if dfu_prefix[:5] != b'DfuSe':
+    if dfu_prefix[:5] != b"DfuSe":
         raise DataError("No valid DfuSe signature")
 
     if dfu_prefix[5] != 0x01:
@@ -658,17 +738,21 @@ def do_dfuse_download(dif: dfu.DfuIf, xfer_size: int,
 
         bAlternateSetting = target_prefix[6]
         if target_prefix[7]:
-            target_name = target_prefix[11:266].split(b"\x00", 1)[0].decode("ascii", "replace")
+            target_name = (
+                target_prefix[11:266].split(b"\x00", 1)[0].decode("ascii", "replace")
+            )
             _logger.info(f"Target name: {target_name}")
         else:
             _logger.info("No target name")
 
         dwNbElements = quad2uint(target_prefix[270:274])
-        _logger.info(f"Image for alternate setting {bAlternateSetting}, "
-                     f"({dwNbElements} elements, "
-                     f"total size = {quad2uint(target_prefix[266:270])})")
+        _logger.info(
+            f"Image for alternate setting {bAlternateSetting}, "
+            f"({dwNbElements} elements, "
+            f"total size = {quad2uint(target_prefix[266:270])})"
+        )
 
-        a_dif: Optional[dfu.DfuIf] = dif
+        a_dif: dfu.DfuIf | None = dif
         while a_dif:
             if bAlternateSetting == a_dif.altsetting:
                 a_dif.dev = dif.dev
@@ -676,8 +760,7 @@ def do_dfuse_download(dif: dfu.DfuIf, xfer_size: int,
                 dev = a_dif.dev
                 assert dev is not None
                 try:
-                    dev.set_interface_altsetting(a_dif.interface,
-                                                 a_dif.altsetting)
+                    dev.set_interface_altsetting(a_dif.interface, a_dif.altsetting)
                 except USBError as e:
                     raise _IOError(f"Cannot set alternate interface: {e}") from e
 
@@ -685,7 +768,9 @@ def do_dfuse_download(dif: dfu.DfuIf, xfer_size: int,
             a_dif = a_dif.next
 
         if not a_dif:
-            _logger.warning(f"No alternate setting {bAlternateSetting} (skipping elements)")
+            _logger.warning(
+                f"No alternate setting {bAlternateSetting} (skipping elements)"
+            )
 
         for element in range(1, dwNbElements + 1):
             _logger.info(f"Parsing element {element}")
@@ -705,18 +790,19 @@ def do_dfuse_download(dif: dfu.DfuIf, xfer_size: int,
 
             if a_dif:
                 ret = download_element(
-                    a_dif, dwElementAddress, dwElementSize,
-                    file.firmware, xfer_size, rt_opts
+                    a_dif,
+                    dwElementAddress,
+                    dwElementSize,
+                    file.firmware,
+                    xfer_size,
+                    rt_opts,
                 )
 
             else:
                 ret = 0
 
             # advance read pointer
-            rem = dfuse_memcpy(
-                None, file.firmware,
-                rem, dwElementSize
-            )
+            rem = dfuse_memcpy(None, file.firmware, rem, dwElementSize)
 
             if ret != 0:
                 return ret
@@ -729,16 +815,19 @@ def do_dfuse_download(dif: dfu.DfuIf, xfer_size: int,
 
 
 @except_and_safe_exit(_logger)
-def do_download(dif: dfu.DfuIf, xfer_size: int, file: DfuFile,
-                dfuse_opts: RuntimeOptions) -> int:
+def do_download(
+    dif: dfu.DfuIf, xfer_size: int, file: DfuFile, dfuse_opts: RuntimeOptions
+) -> int:
     rt_opts = dfuse_opts
     a_dif = dif
     while a_dif:
         assert a_dif.alt_name is not None
         a_dif.mem_layout = parse_memory_layout(a_dif.alt_name)
         if not a_dif.mem_layout:
-            raise _IOError(f"Failed to parse memory layout "
-                           f"for alternate interface {a_dif.altsetting}")
+            raise _IOError(
+                f"Failed to parse memory layout "
+                f"for alternate interface {a_dif.altsetting}"
+            )
 
         if a_dif.quirks and a_dif.quirks & QUIRK.DFUSE_LAYOUT:
             fixup_dfuse_layout(a_dif, a_dif.mem_layout)
@@ -746,9 +835,11 @@ def do_download(dif: dfu.DfuIf, xfer_size: int, file: DfuFile,
 
     if rt_opts.flags & RuntimeOptions.Flags.unprotect:
         if not rt_opts.flags & RuntimeOptions.Flags.force:
-            raise UsageError("The read unprotect command "
-                               "will erase the flash memory"
-                               "and can only be used with force")
+            raise UsageError(
+                "The read unprotect command "
+                "will erase the flash memory"
+                "and can only be used with force"
+            )
         ret = special_command(dif, 0, Command.READ_UNPROTECT, rt_opts)
         _logger.info("Device disconnects, erases flash and resets now")
         return ret
@@ -763,14 +854,15 @@ def do_download(dif: dfu.DfuIf, xfer_size: int, file: DfuFile,
         _logger.info("DfuSe command mode")
         ret = 0
     elif rt_opts.flags & RuntimeOptions.Flags.address_present:
-        if file.bcdDFU == 0x11a:
+        if file.bcdDFU == 0x11A:
             raise UsageError("This is a DfuSe file, not meant for raw download")
         ret = do_bin_download(dif, xfer_size, file, rt_opts.address, rt_opts)
     else:
-        if file.bcdDFU != 0x11a:
+        if file.bcdDFU != 0x11A:
             _logger.warning("Only DfuSe file version 1.1a is supported")
-            raise UsageError("(for raw binary download, "
-                               "use the --dfuse-address option)")
+            raise UsageError(
+                "(for raw binary download, use the --dfuse-address option)"
+            )
         ret = do_dfuse_download(dif, xfer_size, file, rt_opts)
 
     a_dif = dif
@@ -801,14 +893,14 @@ def multiple_alt(dfu_root: dfu.DfuIf) -> int:
     dif = dfu_root.next
 
     while dif:
-        if dev != dif.dev or configuration != dif.configuration or interface != dif.interface:
+        if (
+            dev != dif.dev
+            or configuration != dif.configuration
+            or interface != dif.interface
+        ):
             return 0
         dif = dif.next
     return 1
 
 
-__all__ = (
-    'do_upload',
-    'do_download',
-    'multiple_alt'
-)
+__all__ = ("do_upload", "do_download", "multiple_alt")

--- a/pydfuutil/dfuse_mem.py
+++ b/pydfuutil/dfuse_mem.py
@@ -17,19 +17,23 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
+
+from __future__ import annotations
+
 import logging
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from enum import IntFlag
-from typing import Iterator, Optional, Union
 
 from pydfuutil.logger import logger
 
-_logger = logger.getChild('dfuse_mem')
+_logger = logger.getChild("dfuse_mem")
 
 
 class DFUSE(IntFlag):
     """DFUSE read/write flags"""
+
     READABLE = 0x1
     ERASABLE = 0x2
     WRITEABLE = 0x4
@@ -50,22 +54,20 @@ class MemSegment:
     end: int = 0
     pagesize: int = 0
     mem_type: int = 0
-    next: Optional['MemSegment'] = field(default=None)
+    next: MemSegment | None = field(default=None)
 
     @classmethod
-    def from_bytes(cls, data: bytes) -> 'MemSegment':
+    def from_bytes(cls, data: bytes) -> MemSegment:
         """
         Create a MemSegment stack from binary data
         :param data:
         :return MemSegment:
         """
         return cls(
-            *data[:4],
-            next=MemSegment.from_bytes(data[4:])
-            if len(data) > 4 else None
+            *data[:4], next=MemSegment.from_bytes(data[4:]) if len(data) > 4 else None
         )
 
-    def __iter__(self) -> Iterator['MemSegment']:
+    def __iter__(self) -> Iterator[MemSegment]:
         current = self
         while current is not None:
             yield current
@@ -83,33 +85,25 @@ class MemSegment:
         return ret
 
     def __bytes__(self) -> bytes:
-        data = bytes((
-            self.start,
-            self.end,
-            self.pagesize,
-            self.mem_type
-        ))
+        data = bytes((self.start, self.end, self.pagesize, self.mem_type))
         if self.next:
             data += self.next.__bytes__()
         return data
 
-    def append(self, segment: 'MemSegment') -> None:
+    def append(self, segment: MemSegment) -> None:
         """
         Append the other segment to the stack
         :param segment: MemSegment
         """
         new_segment = MemSegment(
-            segment.start,
-            segment.end,
-            segment.pagesize,
-            segment.mem_type
+            segment.start, segment.end, segment.pagesize, segment.mem_type
         )
         if not self.next:
             self.next = new_segment
         else:
             self.next.append(new_segment)
 
-    def find(self, address: int) -> Optional['MemSegment']:
+    def find(self, address: int) -> MemSegment | None:
         """
         Find a memory segment in the stack containing the given element.
         :param address: MemSegment address for in the stack.
@@ -121,13 +115,15 @@ class MemSegment:
         return None
 
 
-def add_segment(segment_stack: Optional[MemSegment], segment: MemSegment) -> MemSegment:
+def add_segment(segment_stack: MemSegment | None, segment: MemSegment) -> MemSegment:
     """
     :param segment_stack:
     :param segment:
     :return: 0 if ok
     """
-    new_element = MemSegment(segment.start, segment.end, segment.pagesize, segment.mem_type)
+    new_element = MemSegment(
+        segment.start, segment.end, segment.pagesize, segment.mem_type
+    )
 
     if not segment_stack:
         # stack can be empty on the first call
@@ -138,7 +134,7 @@ def add_segment(segment_stack: Optional[MemSegment], segment: MemSegment) -> Mem
     return segment_stack
 
 
-def find_segment(segment_stack: Optional[MemSegment], address: int) -> Optional[MemSegment]:
+def find_segment(segment_stack: MemSegment | None, address: int) -> MemSegment | None:
     """
     Find a memory segment in the stack containing the given element.
 
@@ -154,7 +150,10 @@ def find_segment(segment_stack: Optional[MemSegment], address: int) -> Optional[
 # Parse memory map from interface descriptor string
 # encoded as per ST document UM0424 section 4.3.2.
 
-def parse_memory_layout(intf_desc: Union[str, bytes], verbose: bool = False) -> Optional[MemSegment]:
+
+def parse_memory_layout(
+    intf_desc: str | bytes, verbose: bool = False
+) -> MemSegment | None:
     """
     Parse memory map from interface descriptor string
     encoded as per ST document UM0424 section 4.3.2.
@@ -166,52 +165,54 @@ def parse_memory_layout(intf_desc: Union[str, bytes], verbose: bool = False) -> 
     _logger.setLevel(logging.DEBUG if verbose else logging.INFO)
 
     if isinstance(intf_desc, bytes):
-        intf_desc = intf_desc.decode('ascii')
+        intf_desc = intf_desc.decode("ascii")
 
     count: int = 0
-    segment_stack: Optional[MemSegment] = None
-    address: Optional[int] = None
+    segment_stack: MemSegment | None = None
+    address: int | None = None
 
-    match = re.match(r'@([^/]+)', intf_desc)
+    match = re.match(r"@([^/]+)", intf_desc)
     if match is None:
         _logger.error(f"Could not read name, name={match}")
         return None
     name = match.group(1)
     _logger.info(f"DfuSe interface name: {name}")
 
-    intf_desc = intf_desc[match.end():]
+    intf_desc = intf_desc[match.end() :]
 
     # while per segment
-    while (match := re.match(r'/0x([0-9A-Fa-f]+)/', intf_desc)) is not None:
+    while (match := re.match(r"/0x([0-9A-Fa-f]+)/", intf_desc)) is not None:
         address = int(match.group(1), 16)
 
-        intf_desc = intf_desc[match.end():]
+        intf_desc = intf_desc[match.end() :]
 
         # while per address
-        while (match := re.match(r'(\d+)\*(\d+)(\w)(\w)[,/]?', intf_desc)) is not None:
+        while (match := re.match(r"(\d+)\*(\d+)(\w)(\w)[,/]?", intf_desc)) is not None:
             _sectors, _size, multiplier, type_string = match.groups()
             sectors, size = int(_sectors), int(_size)
 
             _logger.debug(f"{sectors=}, {size=}, {multiplier=}, {type_string=}")
 
-            intf_desc = intf_desc[match.end():]
+            intf_desc = intf_desc[match.end() :]
             count += 1
             mem_type = ord(type_string)
 
             # Quirk for STM32F4 devices
             if name == "Device Feature":
-                mem_type = ord('e')
+                mem_type = ord("e")
 
-            if multiplier == 'B':
+            if multiplier == "B":
                 pass
-            elif multiplier == 'K':
+            elif multiplier == "K":
                 size *= 1024
-            elif multiplier == 'M':
+            elif multiplier == "M":
                 size *= 1024 * 1024
-            elif multiplier in ('a', 'b', 'c', 'd', 'e', 'f', 'g'):
+            elif multiplier in ("a", "b", "c", "d", "e", "f", "g"):
                 if not mem_type:
-                    _logger.warning(f"Non-valid multiplier {multiplier}, "
-                                   "interpreted as type identifier instead")
+                    _logger.warning(
+                        f"Non-valid multiplier {multiplier}, "
+                        "interpreted as type identifier instead"
+                    )
                     mem_type = ord(multiplier)
 
             # fallthrough if mem_type was already set
@@ -223,19 +224,16 @@ def parse_memory_layout(intf_desc: Union[str, bytes], verbose: bool = False) -> 
 
             segment_stack = add_segment(
                 segment_stack,
-                MemSegment(
-                    address,
-                    address + sectors * size - 1,
-                    size,
-                    mem_type & 7
-                )
+                MemSegment(address, address + sectors * size - 1, size, mem_type & 7),
             )
 
-            _logger.debug(f"Memory segment at "
-                         f"0x{address:08x} {sectors} x {size} = {sectors * size} "
-                         f"({'r' if mem_type & DFUSE.READABLE else ''}"
-                         f"{'e' if mem_type & DFUSE.ERASABLE else ''}"
-                         f"{'w' if mem_type & DFUSE.WRITEABLE else ''})")
+            _logger.debug(
+                f"Memory segment at "
+                f"0x{address:08x} {sectors} x {size} = {sectors * size} "
+                f"({'r' if mem_type & DFUSE.READABLE else ''}"
+                f"{'e' if mem_type & DFUSE.ERASABLE else ''}"
+                f"{'w' if mem_type & DFUSE.WRITEABLE else ''})"
+            )
 
             address += sectors * size
 
@@ -247,10 +245,4 @@ def parse_memory_layout(intf_desc: Union[str, bytes], verbose: bool = False) -> 
     return segment_stack
 
 
-__all__ = (
-    "DFUSE",
-    "MemSegment",
-    "add_segment",
-    "find_segment",
-    "parse_memory_layout"
-)
+__all__ = ("DFUSE", "MemSegment", "add_segment", "find_segment", "parse_memory_layout")

--- a/pydfuutil/exceptions.py
+++ b/pydfuutil/exceptions.py
@@ -16,11 +16,13 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
+
+from __future__ import annotations
+
 import logging
 import sys
 from enum import IntEnum
 from functools import wraps
-from typing import Optional
 
 from usb.core import USBError
 from usb.backend.libusb1 import _strerror
@@ -58,9 +60,10 @@ class Errx(Exception):
     that prevented it from completing its task successfully.
     It can also be used as a catch-all for unspecified errors.
     """
+
     exit_code = SysExit.OTHER
 
-    def __init__(self, *args, exit_code: Optional[SysExit] = None):
+    def __init__(self, *args, exit_code: SysExit | None = None):
         super().__init__(*args)
         if isinstance(exit_code, SysExit):
             self.exit_code = exit_code
@@ -68,31 +71,37 @@ class Errx(Exception):
 
 class DataError(Errx, ValueError, TypeError):
     """EX_DATAERR"""
+
     exit_code = SysExit.EX_DATAERR
 
 
 class SoftwareError(Errx):
     """EX_SOFTWARE"""
+
     exit_code = SysExit.EX_SOFTWARE
 
 
 class ProtocolError(Errx):
     """EX_PROTOCOL"""
+
     exit_code = SysExit.EX_PROTOCOL
 
 
 class _IOError(Errx, IOError):
     """EX_IOERR"""
+
     exit_code = SysExit.EX_IOERR
 
 
 class NoInputError(Errx, OSError):
     """EX_NOINPUT"""
+
     exit_code = SysExit.EX_NOINPUT
 
 
 class UsbIOError(Errx, IOError):  # FIXME: Deprecated
     """USB IOError"""
+
     exit_code = SysExit.OTHER
 
 
@@ -103,16 +112,19 @@ class UsageError(Errx):
     invalid command-line arguments or options,
     it might exit with code 2 to indicate a syntax error.
     """
+
     exit_code = SysExit.EX_USAGE  # FIXME: maybe SystemExit + EX.EX_USAGE = 1
 
 
 class CompatibilityError(Errx, OSError):
     """DFU incompatible usage error."""
+
     exit_code = 3  # OSError + EX_PROTOCOL = 3
 
 
 def handle_usb_error(func):
     """patch wrapper to catch a libusb error value"""
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:
@@ -121,10 +133,11 @@ def handle_usb_error(func):
             if e.backend_error_code is None:
                 raise e
             return e.backend_error_code
+
     return wrapper
 
 
-def except_and_safe_exit(_logger: Optional[logging.Logger] = None):
+def except_and_safe_exit(_logger: logging.Logger | None = None):
     """decorator to handle exceptions and exit safely"""
 
     def decorator(func):
@@ -154,16 +167,16 @@ def except_and_safe_exit(_logger: Optional[logging.Logger] = None):
 
 
 __all__ = (
-    'Errx',
-    'NoInputError',
-    'UsageError',
-    'SoftwareError',
-    'ProtocolError',
-    'CompatibilityError',
-    'DataError',
-    'UsbIOError',
-    '_IOError',
-    'except_and_safe_exit',
-    'handle_usb_error',
-    'str_usb_err'
+    "Errx",
+    "NoInputError",
+    "UsageError",
+    "SoftwareError",
+    "ProtocolError",
+    "CompatibilityError",
+    "DataError",
+    "UsbIOError",
+    "_IOError",
+    "except_and_safe_exit",
+    "handle_usb_error",
+    "str_usb_err",
 )

--- a/pydfuutil/logger.py
+++ b/pydfuutil/logger.py
@@ -17,6 +17,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
 
+from __future__ import annotations
+
 import logging
 
 __all__ = ('logger', )

--- a/pydfuutil/lsusb.py
+++ b/pydfuutil/lsusb.py
@@ -17,10 +17,12 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
 
+from __future__ import annotations
+
 import argparse
 import importlib.metadata
 import sys
-from typing import Generator, Optional
+from collections.abc import Generator
 
 import usb._lookup as _lu
 import usb.core
@@ -33,12 +35,14 @@ from pydfuutil.exceptions import except_and_safe_exit, Errx
 try:
     __version__ = importlib.metadata.version("pydfuutil")
 except importlib.metadata.PackageNotFoundError:
-    __version__ = 'UNKNOWN'
+    __version__ = "UNKNOWN"
 
-_logger = logger.getChild('lsusb')
+_logger = logger.getChild("lsusb")
 
-VERSION = (f'pydfuutil-lsusb " v{__version__} "\n {__copyright__[0]}\n'
-           f'This program is Free Software and has ABSOLUTELY NO WARRANTY\n\n')
+VERSION = (
+    f'pydfuutil-lsusb " v{__version__} "\n {__copyright__[0]}\n'
+    f"This program is Free Software and has ABSOLUTELY NO WARRANTY\n\n"
+)
 
 
 class VidPidAction(argparse.Action):
@@ -47,11 +51,13 @@ class VidPidAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         def validate_int(val, base: int = 10):
             try:
-                return int(val, base) if val not in (None, '') else None
+                return int(val, base) if val not in (None, "") else None
             except ValueError:
                 parser.print_help()
-                return parser.error("-d format should be vendor:[product] "
-                                    "vendor and product ID numbers (in hexadecimal)")
+                return parser.error(
+                    "-d format should be vendor:[product] "
+                    "vendor and product ID numbers (in hexadecimal)"
+                )
 
         if values.count(":") > 1:
             validate_int(None)
@@ -75,11 +81,13 @@ class BusDevAction(argparse.Action):
 
         def validate_int(val, base: int = 10):
             try:
-                return int(val, base) if val not in (None, '') else None
+                return int(val, base) if val not in (None, "") else None
             except ValueError:
                 parser.print_help()
-                return parser.error("-s format should be [[bus]:][devnum] "
-                                    "device and/or bus numbers (in decimal)")
+                return parser.error(
+                    "-s format should be [[bus]:][devnum] "
+                    "device and/or bus numbers (in decimal)"
+                )
 
         if values.count(":") > 1:
             validate_int(None)
@@ -104,15 +112,17 @@ class SimulateUnixPath(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         def validate_int(val, base: int = 10):
             try:
-                return int(val, base) if val not in (None, '') else None
+                return int(val, base) if val not in (None, "") else None
             except ValueError:
                 parser.print_help()
-                return parser.error("-D option have to be in format '/dev/bus/usb/<bus>/<port>")
+                return parser.error(
+                    "-D option have to be in format '/dev/bus/usb/<bus>/<port>"
+                )
 
         setattr(namespace, "D", values)
-        if not values.startswith('/dev/bus/usb/'):
+        if not values.startswith("/dev/bus/usb/"):
             parser.error("-D option have to be in format '/dev/bus/usb/<bus>/<port>")
-        bus_devnum = values.split('/')[4:]
+        bus_devnum = values.split("/")[4:]
         if 1 > len(bus_devnum) > 2:
             parser.error("-D option have to be in format '/dev/bus/usb/<bus>/<port>")
         bus, devnum = bus_devnum
@@ -124,43 +134,72 @@ class SimulateUnixPath(argparse.Action):
 def add_cli_options(parser: argparse.ArgumentParser) -> None:
     """Add cli options"""
 
-    parser.add_argument('-v', '--verbose', action='store_true',
-                        help='Increase verbosity (show descriptors)')
-    parser.add_argument('-s', action=BusDevAction,
-                        metavar="[[bus]:][devnum]",
-                        help='Show only devices with specified device '
-                             'and/or bus numbers (in decimal)')
-    parser.add_argument('-d', action=VidPidAction,
-                        metavar='vendor:[product]',
-                        help='Show only devices with the specified vendor '
-                             'and product ID numbers (in hexadecimal)')
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Increase verbosity (show descriptors)",
+    )
+    parser.add_argument(
+        "-s",
+        action=BusDevAction,
+        metavar="[[bus]:][devnum]",
+        help="Show only devices with specified device and/or bus numbers (in decimal)",
+    )
+    parser.add_argument(
+        "-d",
+        action=VidPidAction,
+        metavar="vendor:[product]",
+        help="Show only devices with the specified vendor "
+        "and product ID numbers (in hexadecimal)",
+    )
 
-    if not sys.platform.startswith('win'):
-        parser.add_argument('-D', metavar='device',
-                            action='store',
-                            help='Selects which device lsusb will examine')
-        parser.add_argument('-t', '--tree', action='store_true',
-                            help='Dump the physical USB device hierarchy as a tree')
+    if not sys.platform.startswith("win"):
+        parser.add_argument(
+            "-D",
+            metavar="device",
+            action="store",
+            help="Selects which device lsusb will examine",
+        )
+        parser.add_argument(
+            "-t",
+            "--tree",
+            action="store_true",
+            help="Dump the physical USB device hierarchy as a tree",
+        )
     else:
-        parser.add_argument('-D', metavar='device',
-                            action=SimulateUnixPath,
-                            help='Selects which device lsusb will examine '
-                                 'by UNIX-like path simulate')
-        parser.add_argument('-t', '--tree', action='store_true',
-                            help='Simulate UNIX-like physical USB device hierarchy')
+        parser.add_argument(
+            "-D",
+            metavar="device",
+            action=SimulateUnixPath,
+            help="Selects which device lsusb will examine by UNIX-like path simulate",
+        )
+        parser.add_argument(
+            "-t",
+            "--tree",
+            action="store_true",
+            help="Simulate UNIX-like physical USB device hierarchy",
+        )
 
-    parser.add_argument('-V', '--version', action='version',
-                        version=VERSION,
-                        help='Print the version number')
-    parser.add_argument('-h', '--help', action='store_true',
-                        help='Show this help message and exit')
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=VERSION,
+        help="Print the version number",
+    )
+    parser.add_argument(
+        "-h", "--help", action="store_true", help="Show this help message and exit"
+    )
 
 
-def device_find_filter(dev: usb.core.Device,
-                       vid: Optional[int] = None,
-                       pid: Optional[int] = None,
-                       bus: Optional[int] = None,
-                       address: Optional[int] = None) -> bool:
+def device_find_filter(
+    dev: usb.core.Device,
+    vid: int | None = None,
+    pid: int | None = None,
+    bus: int | None = None,
+    address: int | None = None,
+) -> bool:
     """Custom match callback"""
     # if path is not None and dev.device_address != path:
     #     return False
@@ -175,11 +214,13 @@ def device_find_filter(dev: usb.core.Device,
     return True
 
 
-def list_devices(vid: Optional[int] = None,
-                 pid: Optional[int] = None,
-                 bus: Optional[int] = None,
-                 address: Optional[int] = None,
-                 verbose=False) -> None:
+def list_devices(
+    vid: int | None = None,
+    pid: int | None = None,
+    bus: int | None = None,
+    address: int | None = None,
+    verbose=False,
+) -> None:
     """Prints out founded devices list"""
 
     def custom_match(dev):
@@ -189,10 +230,12 @@ def list_devices(vid: Optional[int] = None,
     sys.exit(0)
 
 
-def iter_devices(vid: Optional[int] = None,
-                 pid: Optional[int] = None,
-                 bus: Optional[int] = None,
-                 address: Optional[int] = None) -> Generator[usb.core.Device, None, None]:
+def iter_devices(
+    vid: int | None = None,
+    pid: int | None = None,
+    bus: int | None = None,
+    address: int | None = None,
+) -> Generator[usb.core.Device, None, None]:
     """Returns a context if fultered devices"""
 
     def custom_match(dev):
@@ -201,11 +244,13 @@ def iter_devices(vid: Optional[int] = None,
     return usb.core.find(find_all=True, custom_match=custom_match)
 
 
-def sym_unix_dev_tree(vid: Optional[int] = None,
-                      pid: Optional[int] = None,
-                      bus: Optional[int] = None,
-                      address: Optional[int] = None,
-                      verbose: bool = False):
+def sym_unix_dev_tree(
+    vid: int | None = None,
+    pid: int | None = None,
+    bus: int | None = None,
+    address: int | None = None,
+    verbose: bool = False,
+):
     """Simulates UNIX device tree"""
     ctx = iter_devices(vid, pid, bus, address)
     for dev in ctx:
@@ -213,23 +258,25 @@ def sym_unix_dev_tree(vid: Optional[int] = None,
         # dev_driver =
         manufacturer = usb.util.get_string(dev, dev.iManufacturer)
         product = usb.util.get_string(dev, dev.iProduct)
-        print(f"/:\tBus {dev.bus:02}.Port {dev.port_number:01}: "
-              f"Dev {dev.address:01}, Class={dev_class}")
+        print(
+            f"/:\tBus {dev.bus:02}.Port {dev.port_number:01}: "
+            f"Dev {dev.address:01}, Class={dev_class}"
+        )
         if verbose:
-            print(f"ID {dev.idVendor:04x}:{dev.idProduct:04x} "
-                  f"{manufacturer}, {product}")
+            print(
+                f"ID {dev.idVendor:04x}:{dev.idProduct:04x} {manufacturer}, {product}"
+            )
 
 
 @except_and_safe_exit(_logger)
 def main():
     """cli entry point for lsusb"""
     parser = argparse.ArgumentParser(
-        prog='pydfuutil-prefix',
-        exit_on_error=False,
-        add_help=False
+        prog="pydfuutil-prefix", exit_on_error=False, add_help=False
     )
-    parser.set_defaults(bus=None, address=None,
-                        vid=None, pid=None, path=None, tree=False)
+    parser.set_defaults(
+        bus=None, address=None, vid=None, pid=None, path=None, tree=False
+    )
     add_cli_options(parser)
     print(f"List USB devices\nv{__version__}")
 
@@ -244,8 +291,7 @@ def main():
 
     verbose = args.verbose
     vid, pid, bus, address = args.vid, args.pid, args.bus, args.address
-    if not sys.platform.startswith('win'):
-
+    if not sys.platform.startswith("win"):
         if args.D:
             parser.print_help()
             parser.error("This version of lsusb does not support -D option")
@@ -262,5 +308,5 @@ def main():
         list_devices(vid, pid, bus, address, verbose)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/pydfuutil/portable.py
+++ b/pydfuutil/portable.py
@@ -17,6 +17,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
 
+from __future__ import annotations
+
 from time import sleep
 __all__ = ("milli_sleep", )
 

--- a/pydfuutil/prefix.py
+++ b/pydfuutil/prefix.py
@@ -17,6 +17,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
 
+from __future__ import annotations
+
 import argparse
 import importlib.metadata
 from pathlib import Path

--- a/pydfuutil/progress.py
+++ b/pydfuutil/progress.py
@@ -17,9 +17,11 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
 
+from __future__ import annotations
+
 import sys
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 
 RICH_PROGRESS: Any = None
@@ -57,9 +59,7 @@ class AbstractProgressBackend(ABC):
         """
 
     @abstractmethod
-    def start_task(
-        self, *, description: Optional[str] = None, total: Optional[int] = None
-    ):
+    def start_task(self, *, description: str | None = None, total: int | None = None):
         """
         Start progress task
         :param description:
@@ -70,9 +70,9 @@ class AbstractProgressBackend(ABC):
     def update(
         self,
         *,
-        description: Optional[str] = None,
-        advance: Optional[int] = None,
-        completed: Optional[int] = None,
+        description: str | None = None,
+        advance: int | None = None,
+        completed: int | None = None,
     ):
         """
         Update progress task
@@ -96,17 +96,15 @@ class NoProgressBarBackend(AbstractProgressBackend):
     def start(self):
         pass
 
-    def start_task(
-        self, *, description: Optional[str] = None, total: Optional[int] = None
-    ):
+    def start_task(self, *, description: str | None = None, total: int | None = None):
         pass
 
     def update(
         self,
         *,
-        description: Optional[str] = None,
-        advance: Optional[int] = None,
-        completed: Optional[int] = None,
+        description: str | None = None,
+        advance: int | None = None,
+        completed: int | None = None,
     ):
         pass
 
@@ -125,10 +123,10 @@ class AsciiBackend(AbstractProgressBackend):
 
     def __init__(self):
         super().__init__()
-        self._value: Optional[int] = None
-        self._total: Optional[int] = None
-        self._rate: Optional[float] = None
-        self._fail: Optional[bool] = None
+        self._value: int | None = None
+        self._total: int | None = None
+        self._rate: float | None = None
+        self._fail: bool | None = None
 
     def _print(self, symbol: str):
         if self.REDIRECT_STD:
@@ -140,9 +138,7 @@ class AsciiBackend(AbstractProgressBackend):
     def start(self):
         pass
 
-    def start_task(
-        self, *, description: Optional[str] = None, total: Optional[int] = None
-    ):
+    def start_task(self, *, description: str | None = None, total: int | None = None):
         self._value = 0
         self._total = total
         self._fail = False
@@ -153,9 +149,9 @@ class AsciiBackend(AbstractProgressBackend):
     def update(
         self,
         *,
-        description: Optional[str] = None,
-        advance: Optional[int] = None,
-        completed: Optional[int] = None,
+        description: str | None = None,
+        advance: int | None = None,
+        completed: int | None = None,
     ):
         total = self._total
         if total:
@@ -203,15 +199,13 @@ class TqdmBackend(AbstractProgressBackend):
     def __init__(self):
         super().__init__()
         self._progress: Any = None
-        self._value: Optional[int] = None
-        self._spinner_state: Optional[int] = None
+        self._value: int | None = None
+        self._spinner_state: int | None = None
 
     def start(self):
         pass
 
-    def start_task(
-        self, *, description: Optional[str] = None, total: Optional[int] = None
-    ):
+    def start_task(self, *, description: str | None = None, total: int | None = None):
         self._value = 0
         if total:
             self._progress = TQDM_PROGRESS(
@@ -247,9 +241,9 @@ class TqdmBackend(AbstractProgressBackend):
     def update(
         self,
         *,
-        description: Optional[str] = None,
-        advance: Optional[int] = None,
-        completed: Optional[int] = None,
+        description: str | None = None,
+        advance: int | None = None,
+        completed: int | None = None,
     ):
         progress = self._progress
         assert progress is not None
@@ -288,7 +282,7 @@ class RichBackend(AbstractProgressBackend):
         super().__init__()
         self._progress: Any = None
         self._task_id: Any = None
-        self._fail: Optional[bool] = None
+        self._fail: bool | None = None
 
     def start(self):
         pass
@@ -304,9 +298,7 @@ class RichBackend(AbstractProgressBackend):
         )
         self._progress.start()
 
-    def start_task(
-        self, *, description: Optional[str] = None, total: Optional[int] = None
-    ):
+    def start_task(self, *, description: str | None = None, total: int | None = None):
         self._prepare()
         self._fail = False
         kwargs = {}
@@ -318,9 +310,9 @@ class RichBackend(AbstractProgressBackend):
     def update(
         self,
         *,
-        description: Optional[str] = None,
-        advance: Optional[int] = None,
-        completed: Optional[int] = None,
+        description: str | None = None,
+        advance: int | None = None,
+        completed: int | None = None,
     ):
         kwargs = {}
         if description is not None:
@@ -394,9 +386,7 @@ class Progress:
         """
         self._backend.start()
 
-    def start_task(
-        self, *, description: Optional[str] = None, total: Optional[int] = None
-    ):
+    def start_task(self, *, description: str | None = None, total: int | None = None):
         """
         Start progress task
         :param description:
@@ -407,9 +397,9 @@ class Progress:
     def update(
         self,
         *,
-        description: Optional[str] = None,
-        advance: Optional[int] = None,
-        completed: Optional[int] = None,
+        description: str | None = None,
+        advance: int | None = None,
+        completed: int | None = None,
     ):
         """
         Update progress task

--- a/pydfuutil/quirks.py
+++ b/pydfuutil/quirks.py
@@ -16,8 +16,10 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
+
+from __future__ import annotations
+
 from enum import IntEnum, IntFlag
-from typing import Union
 
 from pydfuutil.dfuse_mem import MemSegment, find_segment
 from pydfuutil.logger import logger
@@ -64,7 +66,7 @@ class QUIRK(IntFlag):
 
 
 # pylint: disable=invalid-name
-def get_quirks(vendor: int, product: int, bcdDevice: int) -> Union[int, QUIRK]:
+def get_quirks(vendor: int, product: int, bcdDevice: int) -> int | QUIRK:
     """
     Get device specific quirks
     :param vendor: VID

--- a/pydfuutil/suffix.py
+++ b/pydfuutil/suffix.py
@@ -17,6 +17,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
 
+from __future__ import annotations
+
 import argparse
 import importlib.metadata
 from pathlib import Path

--- a/pydfuutil/usb_dfu.py
+++ b/pydfuutil/usb_dfu.py
@@ -21,10 +21,11 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
 
+from __future__ import annotations
+
 import struct
 from dataclasses import dataclass
 from enum import IntEnum, IntFlag
-from typing import Union
 
 
 import usb.util
@@ -52,7 +53,7 @@ class FuncDescriptor:
 
     bLength: int = 0
     bDescriptorType: int = 0
-    bmAttributes: Union[BmAttributes, int] = 0
+    bmAttributes: BmAttributes | int = 0
     wDetachTimeOut: int = 0
     wTransferSize: int = 0
     bcdDFUVersion: int = 0
@@ -69,7 +70,7 @@ class FuncDescriptor:
         )
 
     @staticmethod
-    def from_bytes(data: Union[bytes, bytearray]) -> "FuncDescriptor":  # noqa: F821
+    def from_bytes(data: bytes | bytearray) -> FuncDescriptor:
         """parse bytes to a FuncDescriptor"""
         func_dfu = FuncDescriptor()
         (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "pydfuutil"
 authors = [{ name = "o-murphy", email = "thehelixpg@gmail.com" }]
 description = "PyDfuUtil - Pure python fork of dfu-util wrappers to libusb"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["dfu_util", "dfu-util", "pydfu", "libusb", "python", "python3"]
 license = { file = "LICENSE" }
 classifiers = [
@@ -20,7 +20,6 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -39,12 +38,12 @@ dynamic = ["version"]
 
 [dependency-groups]
 dev = [
-    "pytest>=8.4.2",
+    "pytest>=9.1.1",
     "ruff>=0.15.21",
-    "ty>=0.0.58",
+    "ty>=0.0.59",
     "rich",
     "tqdm",
-    "pre-commit>=4.3.0",
+    "pre-commit>=4.6.0",
 ]
 
 [project.optional-dependencies]

--- a/usb-stubs/backend/libusb1.pyi
+++ b/usb-stubs/backend/libusb1.pyi
@@ -33,7 +33,7 @@ r"""usb.backend.libusb1 - libusb 1.x backend
 Minimal stub covering the symbols used by pydfuutil.
 """
 
-from typing import Callable, Optional
+from collections.abc import Callable
 
 from usb.backend import IBackend
 
@@ -41,5 +41,5 @@ LIBUSB_ERROR_PIPE: int
 
 def _strerror(errcode: int) -> str: ...
 def get_backend(
-    find_library: Optional[Callable[[str], Optional[str]]] = None,
-) -> Optional[IBackend]: ...
+    find_library: Callable[[str], str | None] | None = None,
+) -> IBackend | None: ...

--- a/usb-stubs/control.pyi
+++ b/usb-stubs/control.pyi
@@ -64,7 +64,6 @@ __all__ = [
 ]
 
 import array
-from typing import Union, Tuple, Optional
 
 import usb.core
 import usb.util as util
@@ -73,8 +72,8 @@ import usb.core as core
 USBError = core.USBError
 
 def _parse_recipient(
-    recipient: Optional[Union[usb.core.Interface, usb.core.Endpoint]], direction: int
-) -> Tuple[int, int]: ...
+    recipient: usb.core.Interface | usb.core.Endpoint | None, direction: int
+) -> tuple[int, int]: ...
 
 # standard feature selectors from USB 2.0/3.0
 ENDPOINT_HALT = 0
@@ -86,7 +85,7 @@ LTM_ENABLE = 50
 
 def get_status(
     dev: usb.core.Device,
-    recipient: Optional[Union[usb.core.Interface, usb.core.Endpoint]] = None,
+    recipient: usb.core.Interface | usb.core.Endpoint | None = None,
 ) -> int:
     r"""Return the status for the specified recipient.
 
@@ -109,7 +108,7 @@ def get_status(
 def clear_feature(
     dev: usb.core.Device,
     feature: int,
-    recipient: Optional[Union[usb.core.Interface, usb.core.Endpoint]] = None,
+    recipient: usb.core.Interface | usb.core.Endpoint | None = None,
 ) -> None:
     r"""Clear/disable a specific feature.
 
@@ -125,7 +124,7 @@ def clear_feature(
 def set_feature(
     dev: usb.core.Device,
     feature: int,
-    recipient: Optional[Union[usb.core.Interface, usb.core.Endpoint]] = None,
+    recipient: usb.core.Interface | usb.core.Endpoint | None = None,
 ):
     r"""Set/enable a specific feature.
 
@@ -144,7 +143,7 @@ def get_descriptor(
     desc_type: int,
     desc_index: int,
     wIndex: int = 0,
-) -> Union[int, array.array]:
+) -> int | array.array:
     r"""Return the specified descriptor.
 
     dev is the Device object to which the request will be
@@ -179,10 +178,10 @@ def get_descriptor(
 
 def set_descriptor(
     dev: usb.core.Device,
-    desc: Union[int, bytes, bytearray],
+    desc: int | bytes | bytearray,
     desc_type: int,
     desc_index: int,
-    wIndex: Optional[int] = None,
+    wIndex: int | None = None,
 ) -> None:
     r"""Update an existing descriptor or add a new one.
 
@@ -196,7 +195,7 @@ def set_descriptor(
     it is zero.
     """
 
-def get_configuration(dev: usb.core.Device) -> Union[int, bytes]:
+def get_configuration(dev: usb.core.Device) -> int | bytes:
     r"""Get the current active configuration of the device.
 
     dev is the Device object to which the request will be
@@ -214,7 +213,7 @@ def set_configuration(dev: usb.core.Device, bConfigurationNumber: int) -> None:
     sent to.
     """
 
-def get_interface(dev: usb.core.Device, bInterfaceNumber: int) -> Union[int, bytes]:
+def get_interface(dev: usb.core.Device, bInterfaceNumber: int) -> int | bytes:
     r"""Get the current alternate setting of the interface.
 
     dev is the Device object to which the request will be

--- a/usb-stubs/core.pyi
+++ b/usb-stubs/core.pyi
@@ -58,7 +58,8 @@ import usb._objfinalizer as _objfinalizer
 import logging
 import array
 import threading
-from typing import Union, Any, Literal, Optional, Tuple, Generator, Callable, overload
+from collections.abc import Generator, Callable
+from typing import Any, Literal, overload
 
 from usb.backend import IBackend
 
@@ -67,12 +68,12 @@ _logger = logging.getLogger("usb.core")
 _DEFAULT_TIMEOUT: int = 1000
 _sentinel: object
 
-def _set_attr(input: Any, output: Any, fields: Tuple[str]) -> None: ...
+def _set_attr(input: Any, output: Any, fields: tuple[str]) -> None: ...
 def _try_getattr(object: object, name: str) -> Any: ...
 def _try_get_string(
     dev: Device,
     index: int,
-    langid: Optional[int] = None,
+    langid: int | None = None,
     default_str_i0: str = "",
     default_access_error: str = "Error Accessing String",
 ) -> str:
@@ -113,18 +114,18 @@ class _ResourceManager:
     ) -> None: ...
     @synchronized
     def managed_claim_interface(
-        self, device: Device, intf: Union[Interface, int]
+        self, device: Device, intf: Interface | int
     ) -> None: ...
     @synchronized
     def managed_release_interface(
-        self, device: Device, intf: Union[Interface, int]
+        self, device: Device, intf: Interface | int
     ) -> None: ...
     @synchronized
     def managed_set_interface(
-        self, device: Device, intf: Union[Interface, int], alt: int
+        self, device: Device, intf: Interface | int, alt: int
     ) -> None: ...
     @synchronized
-    def setup_request(self, device: Device, endpoint: Union[Endpoint, int]) -> None:
+    def setup_request(self, device: Device, endpoint: Endpoint | int) -> None:
         # we need the endpoint address, but the "endpoint" parameter
         # can be either the a Endpoint object or the endpoint address itself
         ...
@@ -133,7 +134,7 @@ class _ResourceManager:
     @synchronized
     def get_interface_and_endpoint(
         self, device: Device, endpoint_address: int
-    ) -> Tuple[Interface, Endpoint]: ...
+    ) -> tuple[Interface, Endpoint]: ...
     @synchronized
     def get_active_configuration(self, device: Device) -> Configuration: ...
     @synchronized
@@ -149,7 +150,7 @@ class USBError(IOError):
     member variable.
     """
 
-    backend_error_code: Optional[int]
+    backend_error_code: int | None
     def __init__(
         self, strerror: str, error_code: Any = None, errno: Any = None
     ) -> None:
@@ -223,9 +224,7 @@ class Endpoint:
 
     def __repr__(self) -> str: ...
     def __str__(self) -> str: ...
-    def write(
-        self, data: Union[int, bytes, bytearray], timeout: Optional[int] = None
-    ) -> int:
+    def write(self, data: int | bytes | bytearray, timeout: int | None = None) -> int:
         r"""Write data to the endpoint.
 
         The parameter data contains the data to be sent to the endpoint and
@@ -239,7 +238,7 @@ class Endpoint:
         assert not isinstance(data, int)
         return self.device.write(self, data, timeout)
 
-    def read(self, size_or_buffer: Union[int, bytearray], timeout=None) -> array.array:
+    def read(self, size_or_buffer: int | bytearray, timeout=None) -> array.array:
         r"""Read data from the endpoint.
 
         The parameter size_or_buffer is either the number of bytes to
@@ -314,7 +313,7 @@ class Interface:
     def __str__(self) -> str:
         """Show all information for the interface."""
 
-    def endpoints(self) -> Tuple[Endpoint]:
+    def endpoints(self) -> tuple[Endpoint]:
         r"""Return a tuple of the interface endpoints."""
 
     def set_altsetting(self) -> None:
@@ -368,7 +367,7 @@ class Configuration:
 
     def __repr__(self) -> str: ...
     def __str__(self) -> str: ...
-    def interfaces(self) -> Tuple[Interface]:
+    def interfaces(self) -> tuple[Interface]:
         r"""Return a tuple of the configuration interfaces."""
 
     def set(self) -> Any:
@@ -377,7 +376,7 @@ class Configuration:
     def __iter__(self) -> Generator[Interface, Any, None]:
         r"""Iterate over all interfaces of the configuration."""
 
-    def __getitem__(self, index: Tuple[int, int]) -> Interface:
+    def __getitem__(self, index: tuple[int, int]) -> Interface:
         r"""Return the Interface object in the given position.
 
         index is a tuple of two values with interface index and
@@ -431,7 +430,7 @@ class Device(_objfinalizer.AutoFinalizedObject):
     _serial_number: int
     _product: int
     _manufacturer: int
-    _langids: Tuple[int]
+    _langids: tuple[int]
 
     bLength: int
     bDescriptorType: int
@@ -450,17 +449,17 @@ class Device(_objfinalizer.AutoFinalizedObject):
     address: int
     bus: int
     port_number: int
-    port_numbers: Tuple[int]
+    port_numbers: tuple[int]
     speed: int
 
     _has_parent: bool
-    _parent: Union[Device, None]
+    _parent: Device | None
 
     def __eq__(self, other) -> bool: ...
     def __hash__(self) -> int: ...
     def __repr__(self) -> str: ...
     def __str__(self) -> str: ...
-    def configurations(self) -> Tuple[Configuration]:
+    def configurations(self) -> tuple[Configuration]:
         r"""Return a tuple of the device configurations."""
 
     def __init__(self, dev, backend) -> None:
@@ -474,7 +473,7 @@ class Device(_objfinalizer.AutoFinalizedObject):
         """
 
     @property
-    def langids(self) -> Tuple | Tuple[int, ...]:
+    def langids(self) -> tuple | tuple[int, ...]:
         """Return the USB devices supported language ID codes.
 
         These are 16-bit codes familiar to Windows developers, where for
@@ -503,7 +502,7 @@ class Device(_objfinalizer.AutoFinalizedObject):
         """
 
     @property
-    def parent(self) -> Union[Device, None]:
+    def parent(self) -> Device | None:
         """Return the parent device."""
 
     @property
@@ -518,7 +517,7 @@ class Device(_objfinalizer.AutoFinalizedObject):
     def backend(self) -> IBackend:
         """Return the backend being used by the device."""
 
-    def set_configuration(self, configuration: Optional[Configuration] = None) -> Any:
+    def set_configuration(self, configuration: Configuration | None = None) -> Any:
         r"""Set the active configuration.
 
         The configuration parameter is the bConfigurationValue field of the
@@ -535,8 +534,8 @@ class Device(_objfinalizer.AutoFinalizedObject):
 
     def set_interface_altsetting(
         self,
-        interface: Optional[Union[Interface, int]] = None,
-        alternate_setting: Optional[int] = None,
+        interface: Interface | int | None = None,
+        alternate_setting: int | None = None,
     ) -> None:
         r"""Set the alternate setting for an interface.
 
@@ -572,8 +571,8 @@ class Device(_objfinalizer.AutoFinalizedObject):
     def write(
         self,
         endpoint: Endpoint,
-        data: Union[bytes, bytearray],
-        timeout: Optional[int] = None,
+        data: bytes | bytearray,
+        timeout: int | None = None,
     ) -> int:
         r"""Write data to the endpoint.
 
@@ -592,8 +591,8 @@ class Device(_objfinalizer.AutoFinalizedObject):
     def read(
         self,
         endpoint: Endpoint,
-        size_or_buffer: Union[bytearray, int],
-        timeout: Optional[int] = None,
+        size_or_buffer: bytearray | int,
+        timeout: int | None = None,
     ) -> array.array:
         r"""Read data from the endpoint.
 
@@ -617,9 +616,9 @@ class Device(_objfinalizer.AutoFinalizedObject):
         bRequest: int,
         wValue: int = 0,
         wIndex: int = 0,
-        data_or_wLength: Optional[Union[bytes, bytearray, int]] = None,
-        timeout: Optional[int] = None,
-    ) -> Union[int, array.array]:
+        data_or_wLength: bytes | bytearray | int | None = None,
+        timeout: int | None = None,
+    ) -> int | array.array:
         r"""Do a control transfer on the endpoint 0.
 
         This method is used to issue a control transfer over the endpoint 0
@@ -684,23 +683,23 @@ class Device(_objfinalizer.AutoFinalizedObject):
 @overload
 def find(
     find_all: Literal[True],
-    backend: Optional[IBackend] = None,
-    custom_match: Optional[Callable[[Any], bool]] = None,
+    backend: IBackend | None = None,
+    custom_match: Callable[[Any], bool] | None = None,
     **args,
 ) -> Generator[Device, Any, None]: ...
 @overload
 def find(
     find_all: Literal[False] = False,
-    backend: Optional[IBackend] = None,
-    custom_match: Optional[Callable[[Any], bool]] = None,
+    backend: IBackend | None = None,
+    custom_match: Callable[[Any], bool] | None = None,
     **args,
-) -> Optional[Device]: ...
+) -> Device | None: ...
 def find(
     find_all: bool = False,
-    backend: Optional[IBackend] = None,
-    custom_match: Optional[Callable[[Any], bool]] = None,
+    backend: IBackend | None = None,
+    custom_match: Callable[[Any], bool] | None = None,
     **args,
-) -> Union[Generator[Device, Any, None], Device, None]:
+) -> Generator[Device, Any, None] | Device | None:
     r"""Find an USB device and return it.
 
     find() is the function used to discover USB devices.  You can pass as
@@ -769,7 +768,7 @@ def find(
     Backends are explained in the usb.backend module.
     """
 
-    def device_iter(**kwargs) -> Union[Generator[Device, Any, None], Device, None]: ...
+    def device_iter(**kwargs) -> Generator[Device, Any, None] | Device | None: ...
 
 def show_devices(verbose: bool = False, **kwargs) -> _DescriptorInfo:
     """Show information about connected devices.

--- a/usb-stubs/util.pyi
+++ b/usb-stubs/util.pyi
@@ -48,7 +48,8 @@ get_string - retrieve a string descriptor from the device.
 __author__ = "Wander Lairson Costa"
 
 import array
-from typing import Optional, Union, Generator, Any, Callable, Tuple
+from collections.abc import Generator, Callable
+from typing import Any
 
 import usb.core
 
@@ -144,7 +145,7 @@ def build_request_type(direction: int, type: int, recipient: int):
     Return the bmRequestType value.
     """
 
-def create_buffer(length: Union[bytes, bytearray]) -> array.array:
+def create_buffer(length: bytes | bytearray) -> array.array:
     r"""Create a buffer to be passed to a read function.
 
     A read function may receive an out buffer so the data
@@ -155,14 +156,12 @@ def create_buffer(length: Union[bytes, bytearray]) -> array.array:
     """
 
 def find_descriptor(
-    desc: Union[
-        usb.core.Device,
-        usb.core.Interface,
-        usb.core.Configuration,
-        usb.core.Endpoint,
-    ],
+    desc: usb.core.Device
+    | usb.core.Interface
+    | usb.core.Configuration
+    | usb.core.Endpoint,
     find_all: bool = False,
-    custom_match: Optional[Callable[[Any], bool]] = None,
+    custom_match: Callable[[Any], bool] | None = None,
     **args,
 ) -> Generator[Any, None, None]:
     r"""Find an inner descriptor.
@@ -182,7 +181,7 @@ def find_descriptor(
     """
 
 def claim_interface(
-    device: usb.core.Device, interface: Union[usb.core.Interface, int]
+    device: usb.core.Device, interface: usb.core.Interface | int
 ) -> None:
     r"""Explicitly claim an interface.
 
@@ -196,7 +195,7 @@ def claim_interface(
     """
 
 def release_interface(
-    device: usb.core.Device, interface: Union[usb.core.Interface, int]
+    device: usb.core.Device, interface: usb.core.Interface | int
 ) -> None:
     r"""Explicitly release an interface.
 
@@ -223,7 +222,7 @@ def dispose_resources(device: usb.core.Device) -> None:
     will be allocated automatically.
     """
 
-def get_langids(dev: usb.core.Device) -> Tuple[int]:
+def get_langids(dev: usb.core.Device) -> tuple[int]:
     r"""Retrieve the list of supported Language IDs from the device.
 
     Most client code should not call this function directly, but instead use
@@ -252,7 +251,7 @@ def get_langids(dev: usb.core.Device) -> Tuple[int]:
     of directly calling this function.
     """
 
-def get_string(dev: usb.core.Device, index: int, langid: Optional[int] = None) -> str:
+def get_string(dev: usb.core.Device, index: int, langid: int | None = None) -> str:
     r"""Retrieve a string descriptor from the device.
 
     dev is the Device object which the string will be read from.

--- a/uv.lock
+++ b/uv.lock
@@ -1,34 +1,11 @@
 version = 1
 revision = 3
-requires-python = ">=3.9"
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-    "python_full_version < '3.10'",
-]
-
-[[package]]
-name = "cfgv"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
-]
+requires-python = ">=3.10"
 
 [[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
@@ -57,7 +34,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -66,25 +43,8 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.19.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d", size = 15988, upload-time = "2025-08-14T16:56:01.633Z" },
-]
-
-[[package]]
-name = "filelock"
 version = "3.29.7"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
@@ -92,25 +52,8 @@ wheels = [
 
 [[package]]
 name = "identify"
-version = "2.6.15"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/e7/685de97986c916a6d93b3876139e00eef26ad5bbbd61925d670ae8013449/identify-2.6.15.tar.gz", hash = "sha256:e4f4864b96c6557ef2a1e1c951771838f4edc9df3a72ec7118b338801b11c7bf", size = 99311, upload-time = "2025-10-02T17:43:40.631Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/1c/e5fd8f973d4f375adb21565739498e2e9a1e54c858a97b9a8ccfdc81da9b/identify-2.6.15-py2.py3-none-any.whl", hash = "sha256:1181ef7608e00704db228516541eb83a88a9f94433a8c80bb9b5bd54b1d81757", size = 99183, upload-time = "2025-10-02T17:43:39.137Z" },
-]
-
-[[package]]
-name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
@@ -118,28 +61,8 @@ wheels = [
 
 [[package]]
 name = "importlib-resources"
-version = "6.5.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693, upload-time = "2025-01-03T18:51:56.698Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/ed/1f1afb2e9e7f38a545d628f864d562a5ae64fe6f7a10e28ffb9b185b4e89/importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec", size = 37461, upload-time = "2025-01-03T18:51:54.306Z" },
-]
-
-[[package]]
-name = "importlib-resources"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
@@ -147,25 +70,8 @@ wheels = [
 
 [[package]]
 name = "iniconfig"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
-]
-
-[[package]]
-name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
@@ -176,8 +82,7 @@ name = "libusb-package"
 version = "1.0.30.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-resources", version = "6.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "importlib-resources", version = "7.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "importlib-resources" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/a8/8b3d5dae7340880d556f9f866874b9674b2e3a22fee1e2b96f1ab0feae36/libusb_package-1.0.30.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:2b98784bac3bedda7e95bb5039dd0eded84b02f36110e4d5d607375366c61090", size = 69516, upload-time = "2026-06-30T07:41:02.451Z" },
@@ -192,30 +97,10 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "mdurl", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
-]
-
-[[package]]
-name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version >= '3.10'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
@@ -251,25 +136,8 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.4.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
-]
-
-[[package]]
-name = "platformdirs"
 version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
@@ -286,38 +154,14 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.3.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "cfgv", version = "3.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "identify", version = "2.6.15", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "nodeenv", marker = "python_full_version < '3.10'" },
-    { name = "pyyaml", marker = "python_full_version < '3.10'" },
-    { name = "virtualenv", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/29/7cf5bbc236333876e4b41f56e06857a87937ce4bf91e117a6991a2dbb02a/pre_commit-4.3.0.tar.gz", hash = "sha256:499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16", size = 193792, upload-time = "2025-08-09T18:56:14.651Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/a5/987a405322d78a73b66e39e4a90e4ef156fd7141bf71df987e50717c321b/pre_commit-4.3.0-py2.py3-none-any.whl", hash = "sha256:2b0747ad7e6e967169136edffee14c16e148a778a54e4f967921aa1ebf2308d8", size = 220965, upload-time = "2025-08-09T18:56:13.192Z" },
-]
-
-[[package]]
-name = "pre-commit"
 version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "cfgv", version = "3.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "identify", version = "2.6.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "nodeenv", marker = "python_full_version >= '3.10'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.10'" },
-    { name = "virtualenv", marker = "python_full_version >= '3.10'" },
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
@@ -339,10 +183,8 @@ rich = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pre-commit", version = "4.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pre-commit" },
+    { name = "pytest" },
     { name = "rich" },
     { name = "ruff" },
     { name = "tqdm" },
@@ -359,12 +201,12 @@ provides-extras = ["rich"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pre-commit", specifier = ">=4.3.0" },
-    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pre-commit", specifier = ">=4.6.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
     { name = "rich" },
     { name = "ruff", specifier = ">=0.15.21" },
     { name = "tqdm" },
-    { name = "ty", specifier = ">=0.0.58" },
+    { name = "ty", specifier = ">=0.0.59" },
 ]
 
 [[package]]
@@ -378,42 +220,16 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
-    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "pluggy", marker = "python_full_version < '3.10'" },
-    { name = "pygments", marker = "python_full_version < '3.10'" },
-    { name = "tomli", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
-]
-
-[[package]]
-name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
-    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "pluggy", marker = "python_full_version >= '3.10'" },
-    { name = "pygments", marker = "python_full_version >= '3.10'" },
-    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
@@ -425,10 +241,8 @@ name = "python-discovery"
 version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "filelock", version = "3.29.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "platformdirs", version = "4.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "filelock" },
+    { name = "platformdirs" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4c/81/58c70036dffeccb7fe7d79d6260c69f7a28272bbd3909c29a01ea9422744/python_discovery-1.4.4.tar.gz", hash = "sha256:5cad33982d412c1f3ffb8f9ca4ea292c9680bca3942451d30b69c37fce53a4a3", size = 72212, upload-time = "2026-07-08T23:06:50.691Z" }
 wheels = [
@@ -506,15 +320,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/62/67fc8e68a75f738c9200422bf65693fb79a4cd0dc5b23310e5202e978090/pyyaml-6.0.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da", size = 184450, upload-time = "2025-09-25T21:33:00.618Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/92/861f152ce87c452b11b9d0977952259aa7df792d71c1053365cc7b09cc08/pyyaml-6.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917", size = 174319, upload-time = "2025-09-25T21:33:02.086Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/cd/f0cfc8c74f8a030017a2b9c771b7f47e5dd702c3e28e5b2071374bda2948/pyyaml-6.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9", size = 737631, upload-time = "2025-09-25T21:33:03.25Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/b2/18f2bd28cd2055a79a46c9b0895c0b3d987ce40ee471cecf58a1a0199805/pyyaml-6.0.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5", size = 836795, upload-time = "2025-09-25T21:33:05.014Z" },
-    { url = "https://files.pythonhosted.org/packages/73/b9/793686b2d54b531203c160ef12bec60228a0109c79bae6c1277961026770/pyyaml-6.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a", size = 750767, upload-time = "2025-09-25T21:33:06.398Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/86/a137b39a611def2ed78b0e66ce2fe13ee701a07c07aebe55c340ed2a050e/pyyaml-6.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926", size = 727982, upload-time = "2025-09-25T21:33:08.708Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/62/71c27c94f457cf4418ef8ccc71735324c549f7e3ea9d34aba50874563561/pyyaml-6.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7", size = 755677, upload-time = "2025-09-25T21:33:09.876Z" },
-    { url = "https://files.pythonhosted.org/packages/29/3d/6f5e0d58bd924fb0d06c3a6bad00effbdae2de5adb5cda5648006ffbd8d3/pyyaml-6.0.3-cp39-cp39-win32.whl", hash = "sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0", size = 142592, upload-time = "2025-09-25T21:33:10.983Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/0c/25113e0b5e103d7f1490c0e947e303fe4a696c10b501dea7a9f49d4e876c/pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007", size = 158777, upload-time = "2025-09-25T21:33:15.55Z" },
 ]
 
 [[package]]
@@ -522,8 +327,7 @@ name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "markdown-it-py" },
     { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
@@ -624,27 +428,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.58"
+version = "0.0.59"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/09/4c/26c90732658903aeb1d289208f7b7b492fa21029e0c4d6c51bdd6f8f5e51/ty-0.0.58.tar.gz", hash = "sha256:8f22484174e65c630660a454bf81b80cae7a3a7e70479f19c170d6cd87949258", size = 6133665, upload-time = "2026-07-10T03:09:30.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/b0/84ae7b3bf6e3e9f57eb9635eeff5a80b36e57aa089f40be0fb5c384fa176/ty-0.0.59.tar.gz", hash = "sha256:53e53ffeed78ad59cd237fa8ea1316d2b94e13efdea9a945698acab549e005aa", size = 6145435, upload-time = "2026-07-12T20:22:02.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/e1/5d1aa2a75829459834689f080e4be7a9d8828ce14b939ebed69161a35811/ty-0.0.58-py3-none-linux_armv6l.whl", hash = "sha256:47412850b6fbef61c42f244f6a51aa2f2c9e91f08cfbafd2d1e3730d2419d317", size = 11706915, upload-time = "2026-07-10T03:08:51.028Z" },
-    { url = "https://files.pythonhosted.org/packages/96/e1/929eda9cc72a9afe39a03c76f946a503508d37343cc8ff2e64226afda105/ty-0.0.58-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:79deb7bb4e5b3a1eee6ab9abc724d6ce3559d4977982707f310a139ee11fc703", size = 11532079, upload-time = "2026-07-10T03:08:53.771Z" },
-    { url = "https://files.pythonhosted.org/packages/07/43/ebc58b3fc7d86a7abba2829f1674f7d4ae3a08f9794c1f31b707950c871f/ty-0.0.58-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5a28af3187e661708a386d44a4fc32896a5f589fb07b734a11ab2f516e7572b7", size = 11092983, upload-time = "2026-07-10T03:08:56.025Z" },
-    { url = "https://files.pythonhosted.org/packages/92/6e/9547dbb8e51e47749cfb721a02b4fc862f9a932fa0f66a34a4d6dc429bb1/ty-0.0.58-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21a6977e34bc362fb378add46e59d5d56331c1c36727e6904767217ca8479718", size = 11490492, upload-time = "2026-07-10T03:08:58.49Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/76/9f83b51b5e7795d6c8d76b4bb1bb7cebf4c10d609e846c02ab138e404556/ty-0.0.58-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3ac23e6bf6105ceca46632debf1b10b98125aaf60202aeae02f6abfeea242b3d", size = 11503696, upload-time = "2026-07-10T03:09:00.741Z" },
-    { url = "https://files.pythonhosted.org/packages/47/9d/9fd48a0696c680f74e50f31cd54e524eeb58c97ea9bb1c3b8e04230ba215/ty-0.0.58-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bb6df6a8c6a21894807a49851370ec7fc64aa910296c78ada31db0ef19359112", size = 12158653, upload-time = "2026-07-10T03:09:02.998Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/ea/b5de845d2d8edae04d901c7585af7f04a057e18b26311f7fa4ca62b2da30/ty-0.0.58-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9df5847eebc026cde088b44420a03f7c6c169a7db747176bdf0a656eb1144713", size = 12723019, upload-time = "2026-07-10T03:09:05.291Z" },
-    { url = "https://files.pythonhosted.org/packages/17/1c/54083b23eeff1e101f50b6df6a2c7f1e14b31abe0577c91bcae9e2c9395d/ty-0.0.58-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:53a331a7f1f85872c810676a0f16096ef98c1b95c8c9a573fe7fde64d0a93e7c", size = 12275715, upload-time = "2026-07-10T03:09:07.564Z" },
-    { url = "https://files.pythonhosted.org/packages/22/88/16925434b06faa49d36aa7e7508a6821ec6feacb429ca2fd80a3d52716b4/ty-0.0.58-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb0b05cd479fdcedc2e6781d376ee1a33569f37ae7f58357004635f615c4374c", size = 12033075, upload-time = "2026-07-10T03:09:10.222Z" },
-    { url = "https://files.pythonhosted.org/packages/58/2b/b55708dd483982ae03d14da3667e3f0346cd384e11cca3dd3674a8b598c1/ty-0.0.58-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9a0012786077e5becbb6add9fe51eda1d4d36d249afd3ae6cd141d554af15ae3", size = 12367729, upload-time = "2026-07-10T03:09:12.338Z" },
-    { url = "https://files.pythonhosted.org/packages/91/a3/99ad66652956408f7e9ac3db6b4a416199d773b6c073cf95b0eea126d340/ty-0.0.58-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4ede96d7f6d149156da254e784b062b817736b68d4c6d660555a3d02d96966fb", size = 11439798, upload-time = "2026-07-10T03:09:14.518Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/23/344ceed4fe02ed498711e1f4a47b6e311fb1e9c4fecc19d31894be7a3472/ty-0.0.58-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:47608e58f73901b989402e6f283249cda4c2314282ec368aa74ab61761c62bd5", size = 11512695, upload-time = "2026-07-10T03:09:16.852Z" },
-    { url = "https://files.pythonhosted.org/packages/55/cf/3801831812c468f3fd0b3043a80f557a9aa90e6c27375763d7c3121e03f2/ty-0.0.58-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9757de17cc17e4c6bc26e18d4e26dea52ffee53d41a10d9087c6465e6ab12e2b", size = 11812253, upload-time = "2026-07-10T03:09:19.151Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/80/bce4f245787b77d1ec9feec7d9161eade5e01a77dbc132e016b24df83b0d/ty-0.0.58-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f3776d54c1d935fcb8f814bd58efba402c86c555f93e1144c59d087e7aa8b906", size = 12123918, upload-time = "2026-07-10T03:09:21.636Z" },
-    { url = "https://files.pythonhosted.org/packages/46/00/bab3d6268e7e88c792bf7cdde81bd11b31aa587eaba75196502b729747c8/ty-0.0.58-py3-none-win32.whl", hash = "sha256:8f50ec0ac3b42baa4c75895dc367071dc86b00ab440d29fdc72c633286a94815", size = 11230897, upload-time = "2026-07-10T03:09:23.871Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/68/d9504c895864aaa84a840dce6ac7f8e681f6938be1882c8d4f60832dbe57/ty-0.0.58-py3-none-win_amd64.whl", hash = "sha256:de8847b3a65475ae4773bddd3126bfcf29f017e88967c4dcc9c75d743a4d3e5c", size = 12299376, upload-time = "2026-07-10T03:09:26.292Z" },
-    { url = "https://files.pythonhosted.org/packages/26/04/c9847cb680b5fe8e1f7d7b483edd5cedcc29394496e7b8ed40d96be796ba/ty-0.0.58-py3-none-win_arm64.whl", hash = "sha256:7334bb38789878f60677f2eb9c1de4bfdf4583e2443790989c77da9b10fe0989", size = 11710495, upload-time = "2026-07-10T03:09:28.478Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e8/650b42fbef4d48e6ca682b0b6e9b68fa8fcf55cbb0a6892ab89990018b6f/ty-0.0.59-py3-none-linux_armv6l.whl", hash = "sha256:f8fb08a767ef8f11ea3c537b9d77860726cc2bc39e6f77ad13c02d5b289f20a7", size = 11700328, upload-time = "2026-07-12T20:21:26.046Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ac/0ca3a89d5f59ae5f308e5e83428cac5f9143200767743e052fba90b4b81e/ty-0.0.59-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c7f4d5630836c8a0ba13dd4ac7bdae080a7d6ebe965b817ff642dc961bcf2a53", size = 11494310, upload-time = "2026-07-12T20:21:28.491Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f8/5076de6001cefbccd8e6dc8472262697e43308ff66b0e87c72abba136357/ty-0.0.59-py3-none-macosx_11_0_arm64.whl", hash = "sha256:872f6fb02c6db5553c4d5fb283b3d50f0985fb9a29a910e4fda4793a775c1926", size = 11026797, upload-time = "2026-07-12T20:21:30.879Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/0f/fca28481b6a138e2b798ad9fdc98a095475f9104948ba242fce4b477782b/ty-0.0.59-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2af8eefbfe806337770eec12c0c819c5f1b8f5b85f8369cb1cc9fa25234a2208", size = 11475304, upload-time = "2026-07-12T20:21:33.041Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/1fed8b81b389ef4bbc0400f19e05fc16496b162577779dc0e5fc65ac216c/ty-0.0.59-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0acf8b76a1c9a7ddef460b42475f6c76193164426ab080783af1c3175b4b999b", size = 11533131, upload-time = "2026-07-12T20:21:35.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/fc/04eec35e05a10e0fea1c6503a290ccc3935efda9c845aff64e83282c1af7/ty-0.0.59-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:043c2e00eb1d7475f928af7dedd71f69b64e69bfca55e36f4c968479e1373fc4", size = 12205932, upload-time = "2026-07-12T20:21:37.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/dd/a61de859659fa11b55917ad38340a8f2c61f5ae17d1874929f29084c6990/ty-0.0.59-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0d688d857441df57f48fca66c029d85cf737c510e7be1d01144cdad1e58d968", size = 12758406, upload-time = "2026-07-12T20:21:39.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/e8/fa66f05997eab8ca75fc4f17320140e25467849e0cc75597f898cc22099c/ty-0.0.59-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a96c9f88394a3b42c737e2125b2330543f0d90a43b49761f377d96f8c3ee0d62", size = 12288176, upload-time = "2026-07-12T20:21:41.784Z" },
+    { url = "https://files.pythonhosted.org/packages/15/68/0fca59963bd5123f42d5f7da50667e7a52e8e9615e3a16d8c2c0d3b2d143/ty-0.0.59-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f08dbcb268edcafcb152e59475b5b495ce28d0b340a395c09943557678f4d5a6", size = 12028471, upload-time = "2026-07-12T20:21:43.82Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5b/cd7dabbbab392578f11179919da5c25d8c3322e5388a688f539ea0539603/ty-0.0.59-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:8812764b9a40fdc98df1272826e73a298ef56b06681135e643bcf90aad1896f7", size = 12297646, upload-time = "2026-07-12T20:21:45.76Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/37/2e9c94f0b383d8cbe1a35517ab470b7810bc9d7501603ab532bcd5be5e90/ty-0.0.59-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fd53b8581641d8dad7bfac6d5ea589e91a883d6837e0b9a286fdae30722b7c69", size = 11432519, upload-time = "2026-07-12T20:21:47.694Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0a/af93e9785200f11ac416cc20235fc2464c9bd978e791190684ea0e458795/ty-0.0.59-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:86da5872124a41877d95058bc17d33ddcff034b587eb5f1e2917ab88ba227dac", size = 11554993, upload-time = "2026-07-12T20:21:49.671Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/dd/651bf87e20d00376c81b19124756491cffaf20eb8bec05a8794e5a8cf641/ty-0.0.59-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6a233eef5f2fd4d894881e4a0aec83c9f172bfae1d787d6596ee1939fcc7723e", size = 11818230, upload-time = "2026-07-12T20:21:51.659Z" },
+    { url = "https://files.pythonhosted.org/packages/16/50/c947c4155fea751d135b19affdf734bbce72a94e446b866cf0c62f8bed69/ty-0.0.59-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7ff678c18b5f1e3128b75a35e50dee7908dea55155baa31cd790619d5014cbf5", size = 12135194, upload-time = "2026-07-12T20:21:53.796Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/13/e5feb138888de1e95037c843571bbbd4ac21bf0a190507468098599a321f/ty-0.0.59-py3-none-win32.whl", hash = "sha256:cf8abb4b8095c5fe39102b8127f5886db308c8d4600909ddbc905512ce9c8163", size = 11179249, upload-time = "2026-07-12T20:21:55.752Z" },
+    { url = "https://files.pythonhosted.org/packages/76/dd/52914dcbeeba92c207de40ef7109a58dcb5527aeb21c8f8feb7402aa9e29/ty-0.0.59-py3-none-win_amd64.whl", hash = "sha256:1dde20a82243d24407869e5a608c2f15efddd5cefc662aef461a5af84bfb3f8b", size = 12251079, upload-time = "2026-07-12T20:21:58.1Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8f/ac36fde77e223297454c1e0aeb8888c169eaacf3163bb609e3af942c88cb/ty-0.0.59-py3-none-win_arm64.whl", hash = "sha256:987043ee9e021f49493d9135891ac69c1affeee0d4ad4480c5fa4d9c975fc91b", size = 11650921, upload-time = "2026-07-12T20:22:00.348Z" },
 ]
 
 [[package]]
@@ -658,27 +462,16 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.6.0"
+version = "21.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
-    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "filelock", version = "3.29.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "platformdirs", version = "4.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "filelock" },
+    { name = "platformdirs" },
     { name = "python-discovery" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/65/ec1d92091671e6407d3e7c1f5801413bb7b2b57630a50cae7750456ba0ed/virtualenv-21.6.0.tar.gz", hash = "sha256:e18a4d750f2b64dea73e72ffde3922f3c52365fabdc8157ebd3da20d031c4734", size = 5526111, upload-time = "2026-07-06T22:49:56.972Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/d9/b477fddb68840b570af8b22afe9b035cbc277b5fb7b33dea390617a8b10f/virtualenv-21.6.1.tar.gz", hash = "sha256:15f978b7cd329f24855ff4a0c4b4899cc7678589f49adbdcbbb4d3232e641128", size = 5526620, upload-time = "2026-07-10T19:33:53.312Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/e7/2fbd0cc1653c53eed8f10670538bb547de2b3e37aacad283faa82a71094b/virtualenv-21.6.0-py3-none-any.whl", hash = "sha256:bce9d097950fef9d81129b333babfb7767072850c2f1acce0ec536708401bfd1", size = 5506216, upload-time = "2026-07-06T22:49:54.941Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "3.23.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/7c/4e7225d46d634a0d8d534dd8a6ce0c319d09b4d0cf0337eb314ca4789d8c/virtualenv-21.6.1-py3-none-any.whl", hash = "sha256:afe991df855715a2b2f60edfcc0107ef95a79fdfd8cb4cdaa71603d1c12e463b", size = 5506392, upload-time = "2026-07-10T19:33:51.629Z" },
 ]


### PR DESCRIPTION
### Removed
- Dropped support for Python ≤3.9. `requires-python` is now `>=3.10`; trove classifiers and
  `uv.lock` resolution markers for 3.9 have been removed accordingly.

### Changed
- Modernized type hints across the codebase, enabled by the Python 3.10 floor:
  `Optional[X]`/`Union[X, Y]` → `X | None`/`X | Y` (`dfu.py`, `dfu_file.py`, `dfu_util.py`,
  `dfuse.py`, `dfuse_mem.py`, `exceptions.py`, `lsusb.py`, `progress.py`, `__main__.py`,
  `usb_dfu.py`, `quirks.py`, `usb-stubs/core.pyi`, `usb-stubs/util.pyi`); `typing.Generator`/
  `Callable`/`Iterable`/`Iterator` (PEP 585, deprecated aliases of the `collections.abc` ABCs)
  → `collections.abc` (`dfu_util.py`, `lsusb.py`, `dfuse_mem.py`, `usb-stubs/core.pyi`,
  `usb-stubs/util.pyi`, `usb-stubs/backend/libusb1.pyi`).
- Added `from __future__ import annotations` (PEP 563) to every module in `pydfuutil/`, and
  dropped the now-unnecessary quotes on self-referencing forward-ref annotations
  (`DfuIf.next` in `dfu.py`; `MemSegment.next`/`from_bytes`/`append`/`find` in `dfuse_mem.py`;
  `FuncDescriptor.from_bytes` in `usb_dfu.py`, also dropping its `# noqa: F821`).
- Bumped dev dependencies (`pytest`, `ty`, `pre-commit`) and regenerated `uv.lock`.
- Reformatted the codebase and `usb-stubs/` with the current `ruff` (double-quote strings,
  uppercase hex literals, updated line-wrapping).

### Fixed
- `dfuse_mem.py`/`dfu.py`: `MemSegment`/`DfuIf.next` self-referencing type hints were written as
  `"ClassName" | None` — a string literal `|`'d with `None`, which is invalid at runtime and broke
  both `ty` and every test importing `pydfuutil.dfu` under Python 3.14's dataclass annotation
  evaluation. Fixed by quoting the whole union (`"ClassName | None"`).